### PR TITLE
feat: add permission checks for welcome and wildcard commands

### DIFF
--- a/src/commands/welcome.ts
+++ b/src/commands/welcome.ts
@@ -1,12 +1,35 @@
-import { Client, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { Client, ChatInputCommandInteraction, GuildMember, PermissionsBitField } from 'discord.js';
 import { logMessage } from '../utils/log';
 import { welcomeUser } from '../services/welcomeService';
+import { BOT_USER_ROLE } from '../config';
+
+// Check if user has permission to use welcome command
+function hasWelcomePermission(member: any): boolean {
+    if (!member) return false;
+
+    // Check if user is admin
+    const isAdmin = member.permissions.has(PermissionsBitField.Flags.Administrator);
+    if (isAdmin) return true;
+
+    // Check if user has the specific role
+    const hasRole = member.roles.cache.has(BOT_USER_ROLE);
+    if (hasRole) return true;
+
+    return false;
+}
 
 export async function welcomeSlashCommand(client: Client, interaction: ChatInputCommandInteraction): Promise<void> {
     const guild = interaction.guild;
+    const member = interaction.member;
 
     if (!guild) {
         await interaction.reply({ content: 'Error: Guild not found.', ephemeral: true });
+        return;
+    }
+
+    // Check permissions
+    if (!hasWelcomePermission(member)) {
+        await interaction.reply({ content: 'You do not have permission to use this command. You need admin privileges or the designated role.', ephemeral: true });
         return;
     }
 

--- a/src/commands/wildcard.ts
+++ b/src/commands/wildcard.ts
@@ -1,13 +1,36 @@
-import { Client, ChatInputCommandInteraction } from 'discord.js';
+import { Client, ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
 import { getWILDCARD, setWILDCARD } from '../config';
 import { logMessage } from '../utils/log';
+import { BOT_USER_ROLE } from '../config';
+
+// Check if user has permission to use wildcard command
+function hasWildcardPermission(member: any): boolean {
+    if (!member) return false;
+
+    // Check if user is admin
+    const isAdmin = member.permissions.has(PermissionsBitField.Flags.Administrator);
+    if (isAdmin) return true;
+
+    // Check if user has the specific role
+    const hasRole = member.roles.cache.has(BOT_USER_ROLE);
+    if (hasRole) return true;
+
+    return false;
+}
 
 // Handle the wildcard slash command
 export async function handleWildcardSlashCommand(client: Client, interaction: ChatInputCommandInteraction): Promise<void> {
     const guild = interaction.guild;
+    const member = interaction.member;
 
     if (!guild) {
         await interaction.reply({ content: 'Error: Guild not found.', ephemeral: true });
+        return;
+    }
+
+    // Check permissions
+    if (!hasWildcardPermission(member)) {
+        await interaction.reply({ content: 'You do not have permission to use this command. You need admin privileges or the designated role.', ephemeral: true });
         return;
     }
 


### PR DESCRIPTION
Add permission restrictions to /welcome and /wildcard commands to match the requirements from issue #5.

**Changes:**
- Add  function to restrict  command to admins and designated role holders
- Add  function to restrict  command to admins and designated role holders  
- Provide clear error messages for unauthorized users
- All commands now follow consistent permission patterns

**Command Permissions Summary:**
- : Admin + designated role + pfp-anyone mode
- : Admin only
- : Admin + designated role  
- : Admin + designated role

Closes #5