### PR TITLE
docs: add Tier A governance files (#84)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a defect in hello-dalle-discordbot
+title: "fix: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing! Please describe what you saw, what you expected,
+        and how to reproduce. The more concrete, the faster the fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Concrete description of the bad behavior.
+      placeholder: e.g. "Bot generated a welcome image for a user who already left and rejoined"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: e.g. "No image; rejoiner should be acknowledged in #new-user without re-running DALL-E"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Numbered steps. If you can reproduce in DEBUG mode (`/welcome ... destination:botspam`),
+        say so - that lets us iterate without spamming the welcome channel.
+      placeholder: |
+        1. User joins server
+        2. Same user leaves
+        3. Same user rejoins
+        4. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Bot version
+      description: From `/version` slash command, the startup log line, or the running container tag.
+      placeholder: e.g. "1.12.9"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Which image engine was active?
+      options:
+        - "DALL-E"
+        - "Gemini"
+        - "Both / fallback path triggered"
+        - "N/A - not an image generation issue"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        From `#botspam` or container logs. Redact any tokens before pasting.
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have redacted any tokens / API keys from logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord - introVRt Lounge
+    url: https://discord.gg/introvrt
+    about: Casual questions, deployment help, or just hanging out with the community.
+  - name: Security vulnerability report
+    url: https://github.com/introVRt-Lounge/hello-dalle-discordbot/security/advisories/new
+    about: Private vulnerability report (do NOT use the public bug tracker).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,75 @@
+name: Feature request
+description: Suggest a new capability or behavior change
+title: "feat: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Per CONTRIBUTING.md, features need an
+        issue before implementation work begins.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        The user-facing pain or limitation. Avoid leading with the
+        implementation - describe the experience first.
+      placeholder: e.g. "Users without an avatar get a generated PFP, but there's no way for them to react to keep/regenerate it without DMing a mod."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: A concrete sketch of the behavior. Slash command shape, channel(s), state, edge cases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why they're worse than the proposal.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - "Welcome image flow (guildMemberAdd)"
+        - "Profile picture (/pfp)"
+        - "Wildcard (/wildcard)"
+        - "Engine selection (/engine)"
+        - "Cost monitoring / observability"
+        - "Other"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cost
+    attributes:
+      label: Expected cost impact per invocation
+      description: |
+        Rough order of magnitude for the new feature - DALL-E is ~$0.04/image,
+        Gemini is ~$0.08/image. "Free" means no AI API calls.
+      options:
+        - "Free (no AI API call)"
+        - "Low (1 AI API call, ~$0.04 - $0.08)"
+        - "Medium (2-5 calls)"
+        - "High (>5 calls or per-message)"
+        - "Unknown - want input on this"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues / TODO.md and this is not a duplicate.
+          required: true
+        - label: I understand this requires an issue before implementation work begins.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing! A few requests before we review:
+
+- Title should follow Conventional Commits (feat: / fix: / chore: / docs: / refactor: / test: / ci:)
+- Body must reference an issue (e.g. "Fixes #123") unless this is a one-line typo or doc fix
+- All CI checks must pass (lint, test, secret-scan, owasp-sast, ci aggregate)
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing WHAT changed and WHY. Implementation detail belongs below. -->
+
+-
+
+## Linked issue
+
+Fixes #
+
+## Test plan
+
+- [ ] `npm test` passes locally
+- [ ] If touching the welcome flow: tested via `/welcome ... destination:botspam` (debug mode, no #new-user spam)
+- [ ] If touching image generation: integration test passes with at least one engine
+- [ ] If touching the Dockerfile: `docker build --target test` and `--target production` both succeed
+- [ ] If touching CI: ran `gitleaks detect` and `semgrep scan` locally where applicable
+
+## Notes for reviewers
+
+<!-- Anything tricky, risk, follow-ups, or rollback plan. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+Coding agents (Claude, Cursor, Codex, etc.) working in this repository must
+follow the rules below. Human contributors should follow CONTRIBUTING.md.
+
+## Issues-first workflow (mandatory)
+
+**No ticket, no workee.** Do not implement features or bugfixes requested in
+chat until a tracking GitHub Issue exists.
+
+| Request in chat | Agent action |
+|-----------------|--------------|
+| New feature | Create issue (`feat: ...`) via `gh issue create`, then branch |
+| Bug / regression | Create issue (`fix: ...`), then branch |
+| Question / explanation only | Answer; no issue required |
+| Docs typo (one line) | Fix directly; issue optional |
+
+Before writing implementation code:
+
+1. Confirm repo has a GitHub remote and `gh` is authenticated as the
+   identity that owns the repo.
+2. Open or find the issue; note the number.
+3. Branch name should include the issue number when practical
+   (`feat/123-short-name`, `fix/123-short-name`).
+4. PR body must include `Fixes #N`.
+
+**Exceptions** (no issue required):
+
+- Operator explicitly says "skip issue" or "no ticket".
+- One-line typos, comment-only edits, or doc fixes with no behavior change.
+- Active production incident when the operator declares hotfix mode.
+
+If the operator describes substantive work but no issue exists,
+**create the issue first**, paste the URL back, then proceed.
+
+## Bot persona
+
+This repo carries a `.cursor/rules/hello-dalle-bot-persona.mdc` rule that
+asks the agent to respond in character as the hello-dalle Discord bot.
+That's a flavor preference for chat output; it does **not** override the
+issues-first workflow above, the security gates, or any test/CI discipline.
+
+## CI / security discipline
+
+Every PR must pass:
+
+- `lint` (TypeScript type-check)
+- `test` (jest)
+- `secret-scan` (gitleaks)
+- `owasp-sast` (Semgrep OWASP Top 10 + JS/TS + secrets + project rules)
+- `ci` aggregate gate
+
+If a Semgrep rule flags a real issue in code under your control, **fix the
+issue**. Do not suppress the rule with `# nosemgrep:` unless the operator
+explicitly approves.
+
+If the gate flags a false positive on an unrelated file, add a path entry
+to `.semgrepignore` (not a per-line suppression) and explain in the PR body.
+
+## Conventional commits
+
+Semantic-release computes the next version from commit messages on `main`:
+
+- `feat:` -> minor bump
+- `fix:` -> patch bump
+- `feat!:` or `BREAKING CHANGE:` footer -> major bump
+- Other prefixes (`chore:`, `docs:`, `refactor:`, `test:`, `ci:`) -> no bump
+
+Get the prefix right. If in doubt, ask the operator before commit, not after.
+
+## Secrets
+
+Never commit `.env`, `.env.test`, or anything resembling a Discord bot token,
+OpenAI key, or Gemini key. The pre-commit type-check is fast; the pre-push
+hook runs the full Jest suite twice (local + CI-sim) before the push leaves
+the machine. The `secret-scan` job in CI is the third line of defense.
+
+If you discover a leaked credential in any branch:
+
+1. Tell the operator immediately. **Do not push** to a branch that
+   contains the leak.
+2. Rotate the credential at the issuing provider.
+3. Rewrite history if needed (operator approves).
+
+## What the agent should NOT do without explicit operator approval
+
+- Force-push to `main`.
+- Disable CI workflows.
+- Commit anything from the operator's home directory or workspace files
+  outside this repo.
+- Approve / merge their own PRs (operator must review).
+- Create releases or tags manually (semantic-release owns this).
+- Toggle branch protection rules.
+
+## What the agent SHOULD do proactively
+
+- Run tests locally before pushing.
+- Update `TODO.md` when work completes or new follow-ups surface.
+- Open follow-up issues when scope creep would otherwise pollute the
+  current PR.
+- Pin Docker / GitHub Action versions instead of using floating tags.
+- Use `gh` (not curl + manual JSON) for GitHub API operations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,121 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action
+in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces - this repository,
+its issue tracker and pull requests, the introVRt Lounge Discord server, and
+any other space where the project's code or community presence is involved.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via the
+**Security tab -> Report a vulnerability** flow on GitHub (works for conduct
+reports too) or by DM to a server admin in introVRt Lounge Discord.
+
+All complaints will be reviewed and investigated promptly and fairly. All
+community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior
+deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders,
+providing clarity around the nature of the violation and an explanation
+of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, for a specified period of time.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to hello-dalle-discordbot
+
+Thanks for considering a contribution! This bot powers welcome images and
+profile-picture suggestions for the **introVRt Lounge** Discord server. The
+public repo is the upstream and we do welcome external PRs.
+
+## Issues-first
+
+**No ticket, no workee.** Features and bugs require an open GitHub Issue
+**before** implementation work.
+
+- Feature: open a `Feature request` issue, describe the user-facing change.
+- Bug: open a `Bug report` issue with reproduction steps and expected vs.
+  observed behavior.
+- One-line typo or comment-only doc edit: an issue is optional.
+
+PRs without a linked issue may be asked to open one before review.
+
+## Local setup
+
+Prerequisites:
+
+- Node.js 22 LTS (matches CI and runtime)
+- Docker (optional, for running the bot in a container)
+
+```bash
+git clone https://github.com/introVRt-Lounge/hello-dalle-discordbot.git
+cd hello-dalle-discordbot
+cp .env.example .env       # then fill in values
+npm ci
+npm run start:dev
+```
+
+`.env` values you'll need to populate are documented in [README.md](./README.md#environment-variables).
+Test-time fixtures live in `.env.test` (not committed).
+
+## Development workflow
+
+| Step | Command |
+|---|---|
+| Type-check | `npm run type-check` |
+| Build | `npm run build` |
+| Run tests | `npm test` |
+| Run integration tests (live API calls, costs money) | `npm run test:integration` |
+| Run dev bot | `npm run start:dev` |
+
+Husky hooks are installed via `prepare` and enforce locally:
+
+- `pre-commit`: TypeScript type-check on staged files
+- `pre-push`: full Jest suite in both local and CI-simulated environments
+
+To skip hooks for an emergency push, use `git push --no-verify` and explain
+in the PR description.
+
+## Branching and PRs
+
+1. Branch off `main`. Names: `feat/<n>-short-desc`, `fix/<n>-short-desc`,
+   `chore/<n>-short-desc`, `docs/<n>-short-desc`.
+2. Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+   for commit messages and PR titles. Semantic-release uses these to compute
+   the next version on merge to `main`.
+   - `feat:` -> minor bump
+   - `fix:` -> patch bump
+   - `feat!:` or footer `BREAKING CHANGE:` -> major bump
+3. PR body must include `Fixes #N` (or `Refs #N`) so the linked issue auto-
+   closes on merge.
+4. Branch protection on `main` requires:
+   - Status check `ci` (lint + test + secret-scan + owasp-sast) green
+   - At least 1 approval
+   - Linear history (rebase or squash, no merge commits)
+5. Squash-merge is the default; the branch is auto-deleted on merge.
+
+## CI / security gates
+
+Every PR runs (see `.github/workflows/ci.yml`):
+
+| Job | What |
+|---|---|
+| `lint` | TypeScript type-check |
+| `test` | Jest suite (40+ cases) |
+| `secret-scan` | gitleaks 8.x with `.gitleaks.toml` allowlist |
+| `owasp-sast` | Semgrep `1.122.0` against OWASP Top 10 + JS/TS + secrets + project rules |
+| `ci` | Aggregate gate (required check for branch protection) |
+
+`secret-scan` will catch secrets accidentally staged - including API keys,
+Discord tokens, and OpenAI/Gemini keys. `owasp-sast` will reject patterns
+like hard-coded secrets, missing Dockerfile `USER`, etc.
+
+## Reporting security issues
+
+Do **not** open a public issue for security vulnerabilities. See
+[SECURITY.md](./SECURITY.md) for the private reporting path.
+
+## Code of Conduct
+
+Participation in this project is governed by our
+[Code of Conduct](./CODE_OF_CONDUCT.md). By contributing you agree to
+uphold it.
+
+## Releasing
+
+Releases are automatic via [`semantic-release`](https://semantic-release.gitbook.io/semantic-release/)
+on merge to `main`. The release workflow (`.github/workflows/release.yml`)
+computes the next version from commit history, tags it, builds the Docker
+image, and pushes to Docker Hub (`heavygee/hello-dalle-discordbot:<version>`).
+Watchtower picks it up in production.
+
+You should never need to bump the version manually. If a commit's prefix is
+wrong, fix it before merge - that's what determines the bump.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in
+`hello-dalle-discordbot`, **please do not open a public GitHub Issue.**
+
+### Preferred: GitHub private advisory
+
+1. Go to the repo's
+   [Security tab](https://github.com/introVRt-Lounge/hello-dalle-discordbot/security/advisories).
+2. Click **Report a vulnerability**.
+3. Fill in the form; only repository maintainers can see your report.
+
+This route gives us a private channel, an auto-assigned CVE if applicable,
+and a coordinated disclosure timeline.
+
+### Alternative: Discord DM
+
+If you cannot use GitHub advisories, send a DM on Discord to a maintainer
+of the **introVRt Lounge** server (look for the `Owner` or `Admin` role).
+Include:
+
+- A description of the vulnerability
+- Steps to reproduce
+- The bot version affected (`/version` or container tag)
+- Your contact info for follow-up
+
+We will acknowledge within **72 hours** and keep you updated on the fix.
+
+## Scope
+
+In scope:
+
+- The published Docker image: `heavygee/hello-dalle-discordbot:*`
+- The source code in this repository on the `main` branch
+- The bot's behavior in production (introVRt Lounge Discord server)
+
+Out of scope:
+
+- Discord platform issues (report to Discord)
+- OpenAI / Google Gemini API issues (report to the respective providers)
+- Forks of this repo
+
+## Secrets and runtime configuration
+
+Never commit `.env`, `.env.test`, or any file containing real API keys,
+Discord tokens, or OAuth secrets. The CI pipeline includes a `secret-scan`
+job (gitleaks) that fails the build if secret-shaped strings are found.
+
+If you accidentally push a secret:
+
+1. **Rotate the credential immediately** at the issuing provider.
+2. Open a private advisory describing the exposure window.
+3. Do not just `git revert` - the secret stays in the git history.
+
+## Supported versions
+
+Only the latest minor version on `main` (and the corresponding
+`heavygee/hello-dalle-discordbot:latest` Docker image) receives security
+patches. Backports are not provided.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "keywords": [],
   "author": "HeavyGee and ChatGPT",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@octokit/rest": "^22.0.0",


### PR DESCRIPTION
Closes #84.

## Summary

Adds the public-OSS Tier A governance baseline per the ``perfect-github-setup-and-operation`` skill.

| File | Purpose |
|---|---|
| ``CONTRIBUTING.md`` | Setup, dev workflow, branching, PR rules, conventional commits, issues-first |
| ``SECURITY.md`` | Private vulnerability advisory path + Discord DM fallback |
| ``CODE_OF_CONDUCT.md`` | Contributor Covenant 2.1 |
| ``AGENTS.md`` | Rules for coding agents (issues-first, allowed/forbidden actions) |
| ``.github/ISSUE_TEMPLATE/bug_report.yml`` | Structured bug intake (bot version, engine, redacted logs) |
| ``.github/ISSUE_TEMPLATE/feature_request.yml`` | Scope + per-invocation cost prompts |
| ``.github/ISSUE_TEMPLATE/config.yml`` | Blank issues disabled; Discord + advisory contact links |
| ``.github/pull_request_template.md`` | Fixes #N + test plan checklist |

## Bonus correctness fix

``package.json`` ``"license"`` field said ``ISC`` but ``LICENSE`` is **MIT**. Updated ``package.json`` to ``MIT`` so the npm metadata matches the authoritative legal document.

## Test plan

- [x] ``npm test`` passes (40 passed, 4 skipped)
- [x] All new ``.yml`` files lint as valid YAML

## Notes

- The ``Discord - introVRt Lounge`` invite link in ``ISSUE_TEMPLATE/config.yml`` is ``discord.gg/introvrt`` - **please confirm or correct**, I guessed based on the org name. Easy follow-up if wrong.
- The bug-report template asks for the bot version - the ``/version`` slash command does not currently exist. Operator can either add that command (separate issue) or I can change the prompt to ask for the container tag instead.

Made with [Cursor](https://cursor.com)