### PR TITLE
docs: add Tier B hygiene + label sync (#85)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,tsx,js,jsx,json,yml,yaml,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,73 @@
+# Canonical label set for hello-dalle-discordbot.
+# Quote color values as strings - YAML 1.1 will otherwise parse e.g.
+# "5319e7" as scientific notation (5319 * 10^7) and label-sync will reject.
+
+# Type
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or improvement
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to docs
+- name: refactor
+  color: "fbca04"
+  description: Internal cleanup with no behavior change
+- name: ci
+  color: "1d76db"
+  description: CI / build / release tooling
+- name: security
+  color: "ee0701"
+  description: Security-relevant change or finding
+
+# Status
+- name: blocked
+  color: "b60205"
+  description: Cannot proceed without external action
+- name: needs-info
+  color: "fef2c0"
+  description: Awaiting more information from the reporter
+- name: wontfix
+  color: "ffffff"
+  description: This will not be worked on
+- name: duplicate
+  color: "cfd3d7"
+  description: This issue or PR already exists
+
+# Triage / contributor experience
+- name: good first issue
+  color: "7057ff"
+  description: A good entry point for new contributors
+- name: help wanted
+  color: "008672"
+  description: Extra attention is needed
+
+# Domain
+- name: area/welcome
+  color: "5319e7"
+  description: Welcome image flow (guildMemberAdd)
+- name: area/pfp
+  color: "5319e7"
+  description: Profile picture flow (/pfp)
+- name: area/wildcard
+  color: "5319e7"
+  description: Wildcard prompts (/wildcard)
+- name: area/engine
+  color: "5319e7"
+  description: Engine selection (DALL-E vs Gemini)
+- name: area/cost-monitoring
+  color: "5319e7"
+  description: Cost reporting and budget controls
+- name: area/docker
+  color: "5319e7"
+  description: Container build and runtime
+- name: area/ci
+  color: "5319e7"
+  description: GitHub Actions, gates, branch protection
+
+# Dependencies
+- name: dependencies
+  color: "0366d6"
+  description: Pull requests that update a dependency file

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,24 @@
+name: label-sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/label-sync.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Sync labels from .github/labels.yml
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases are computed automatically by [`semantic-release`](https://semantic-release.gitbook.io/semantic-release/)
+on merge to `main`. The canonical, machine-generated history lives on the
+[GitHub Releases](https://github.com/introVRt-Lounge/hello-dalle-discordbot/releases)
+page; this file is the human-curated mirror starting from `1.13.0`.
+
+## [Unreleased]
+
+### Added
+
+- `data/welcomedUsers.json` persistence so users who leave and rejoin do
+  not trigger a fresh welcome image generation. (#81, PR #82)
+- Lean `ci.yml` PR gate with lint, test, gitleaks `secret-scan`, Semgrep
+  `owasp-sast`, and an aggregate `ci` job for branch protection. (#83, PR #87)
+- Tier A governance: `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`,
+  `AGENTS.md`, `.github/ISSUE_TEMPLATE/`, `.github/pull_request_template.md`.
+  (#84, PR #88)
+- Tier B hygiene: this `CHANGELOG.md`, `SUPPORT.md`, `.editorconfig`,
+  `.github/labels.yml` + `label-sync` workflow. (#85, this PR)
+
+### Changed
+
+- Rejoin greeting moved from `#botspam` (admin-only) to the user-facing
+  welcome channel; respects `STEALTH_WELCOME` for mention behavior.
+- `Dockerfile` now drops to `USER node` in both the test and production
+  stages (was running as root). Full Dockerfile modernization tracked
+  in #86.
+- `package.json` `"license"` corrected from `"ISC"` to `"MIT"` to match
+  the authoritative `LICENSE` file.
+
+### Removed
+
+- Dead `.github/workflows/ci-cd.yml.disabled` file.
+
+## Older history
+
+Releases prior to this curated changelog (`1.0.0` through `1.12.9`) live
+on the [GitHub Releases page](https://github.com/introVRt-Lounge/hello-dalle-discordbot/releases).
+
+[Unreleased]: https://github.com/introVRt-Lounge/hello-dalle-discordbot/compare/v1.12.9...HEAD

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,57 @@
+# Support
+
+Need help with hello-dalle-discordbot? Here's where to go.
+
+## Discord (fastest)
+
+The bot lives in **introVRt Lounge** Discord. Casual questions, deployment
+help, screenshots of weird behavior - drop them in `#bots-and-tech` (or
+DM a server admin). You'll usually get a reply same-day.
+
+Invite: https://discord.gg/introvrt
+
+## GitHub Issues (for tracked work)
+
+- **Bug?** Open a [bug report](https://github.com/introVRt-Lounge/hello-dalle-discordbot/issues/new?template=bug_report.yml).
+- **Feature idea?** Open a [feature request](https://github.com/introVRt-Lounge/hello-dalle-discordbot/issues/new?template=feature_request.yml).
+- **Security vulnerability?** Use the [private advisory flow](https://github.com/introVRt-Lounge/hello-dalle-discordbot/security/advisories/new) - **never** the public bug tracker.
+
+Per [CONTRIBUTING.md](./CONTRIBUTING.md), features and bugs require an issue
+before any PR work begins ("no ticket no workee"). One-line typos and doc
+fixes can skip the issue.
+
+## Self-hosters
+
+Most "the bot doesn't post images" reports trace back to:
+
+1. **API key missing or out of credit** - check container logs for
+   `OPENAI_API_KEY is not set` or `quota exceeded`.
+2. **Channel ID typos** - `WELCOME_CHANNEL_ID` and `BOTSPAM_CHANNEL_ID`
+   must be the numeric channel IDs (right-click channel -> Copy ID with
+   developer mode on), not channel names.
+3. **Missing intents** - the bot needs `SERVER_MEMBERS_INTENT` and
+   `MESSAGE_CONTENT_INTENT` enabled in the Discord developer portal.
+4. **`POSTING_DELAY` confusion** - the bot intentionally waits 2 minutes
+   (default) before posting to `#welcome` so the user sees onboarding
+   first. Check `#botspam` for confirmation that the image was generated.
+
+Full env-var reference and Docker setup live in [README.md](./README.md).
+Production-deployment specifics: [PRODUCTION_DEPLOYMENT.md](./PRODUCTION_DEPLOYMENT.md).
+
+## Costs
+
+Image generation isn't free. Approximate per-image costs:
+
+- DALL-E 3: ~$0.04 / image
+- Gemini (image-to-image, 2 calls): ~$0.08 / image
+
+If you're seeing unexpected billing, check `#botspam` for the cost-monitoring
+report and look for runaway loops (e.g. the same user re-triggering welcomes -
+that's the bug fixed in PR #82).
+
+## Things we will NOT help with
+
+- Building a different Discord bot from this codebase (fork it; we won't
+  customize for your server)
+- Bypassing Discord's rate limits or terms of service
+- Generating images that violate OpenAI / Google content policies


### PR DESCRIPTION
Closes #85.

## Summary

Public-OSS Tier B hygiene per the ``perfect-github-setup-and-operation`` skill.

| File | Purpose |
|---|---|
| ``SUPPORT.md`` | Discord-first support routing, common self-host gotchas, cost rough-OOMs |
| ``CHANGELOG.md`` | Keep a Changelog 1.1; curated history forward, GitHub Releases for older |
| ``.editorconfig`` | Indent + EOL conventions matching existing tsconfig |
| ``.github/labels.yml`` | 20 canonical labels (type / status / contributor / area/* / dependencies) |
| ``.github/workflows/label-sync.yml`` | ``EndBug/label-sync@v2`` driven by pushes to ``labels.yml`` |

## YAML 1.1 footgun handled

All ``color:`` values in ``labels.yml`` are explicitly quoted as strings. Per the skill, unquoted hex like ``5319e7`` parses as scientific notation (``5.319 * 10^7``) and breaks ``label-sync``. Local validator confirms 20/20 labels parse with valid 6-char hex colors.

## ``delete-other-labels: false``

Set additive-only on the first run so any in-flight labels on existing issues survive. Operator can flip to ``true`` later if they want strict canonicalization.

## Test plan

- [x] YAML schema validated locally (``js-yaml`` parse + per-label color regex)
- [ ] After merge: ``label-sync`` workflow auto-runs from the push, creates 20 labels
- [ ] Operator sanity-check: ``gh label list --repo introVRt-Lounge/hello-dalle-discordbot``

Made with [Cursor](https://cursor.com)