### PR TITLE
chore(ci): fix manual-publish git-tag identity + record v1.31.3 in CHANGELOG

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -116,13 +116,18 @@ jobs:
         run: |
           set -euo pipefail
           TAG='${{ inputs.tag }}'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "$TAG"
           git push origin "refs/tags/$TAG"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --target "${GITHUB_SHA}" \
-            --generate-notes \
-            --notes-start-tag v1.31.2
+          # GitHub creates the release tied to the existing tag; do not pass --target,
+          # it conflicts with an already-pushed tag and returns HTTP 422.
+          PREV_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || echo '')
+          if [ -n "$PREV_TAG" ]; then
+            gh release create "$TAG" --title "$TAG" --generate-notes --notes-start-tag "$PREV_TAG"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -43,9 +43,10 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG='${{ inputs.tag }}'
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
             echo "::error::tag '$TAG' is not vMAJOR.MINOR.PATCH (e.g. v1.31.3)"
             exit 1
@@ -57,9 +58,10 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Generate version files
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG='${{ inputs.tag }}'
           echo "${TAG#v}" > version.txt
           {
             echo "VERSION=${TAG#v}"
@@ -78,10 +80,11 @@ jobs:
 
       - name: Build tag list
         id: tags
+        env:
+          TAG: ${{ inputs.tag }}
+          ALSO_LATEST: ${{ inputs.also_latest }}
         run: |
           set -euo pipefail
-          TAG='${{ inputs.tag }}'
-          ALSO_LATEST='${{ inputs.also_latest }}'
           IMAGE='heavygee/hello-dalle-discordbot'
           {
             echo "tags<<EOF"
@@ -113,9 +116,9 @@ jobs:
         if: ${{ inputs.create_release == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG='${{ inputs.tag }}'
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "$TAG"
@@ -130,12 +133,16 @@ jobs:
           fi
 
       - name: Summary
+        env:
+          TAG: ${{ inputs.tag }}
+          ALSO_LATEST: ${{ inputs.also_latest }}
+          CREATE_RELEASE: ${{ inputs.create_release }}
         run: |
           {
             echo "## Manual publish complete"
             echo ""
-            echo "- Image: \`heavygee/hello-dalle-discordbot:${{ inputs.tag }}\`"
-            echo "- Also \`:latest\`: \`${{ inputs.also_latest }}\`"
-            echo "- GitHub release: \`${{ inputs.create_release }}\`"
+            echo "- Image: \`heavygee/hello-dalle-discordbot:${TAG}\`"
+            echo "- Also \`:latest\`: \`${ALSO_LATEST}\`"
+            echo "- GitHub release: \`${CREATE_RELEASE}\`"
             echo "- Commit: \`${GITHUB_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ page; this file is the human-curated mirror starting from `1.13.0`.
 
 ## [Unreleased]
 
+## [1.31.3] - 2026-06-03
+
 ### Added
 
 - `data/welcomedUsers.json` persistence so users who leave and rejoin do
@@ -43,4 +45,5 @@ page; this file is the human-curated mirror starting from `1.13.0`.
 Releases prior to this curated changelog (`1.0.0` through `1.12.9`) live
 on the [GitHub Releases page](https://github.com/introVRt-Lounge/hello-dalle-discordbot/releases).
 
-[Unreleased]: https://github.com/introVRt-Lounge/hello-dalle-discordbot/compare/v1.12.9...HEAD
+[Unreleased]: https://github.com/introVRt-Lounge/hello-dalle-discordbot/compare/v1.31.3...HEAD
+[1.31.3]: https://github.com/introVRt-Lounge/hello-dalle-discordbot/compare/v1.31.2...v1.31.3


### PR DESCRIPTION
## Summary

Two small fixes uncovered while shipping today's v1.31.3 manually via the new `manual-publish` workflow (#96):

1. The `Create git tag and GitHub release` step crashed with `fatal: empty ident name (for runner@...)` because the runner had no committer identity configured. Now sets `github-actions[bot]` before `git tag -a`.
2. `gh release create` was passed both `--target $GITHUB_SHA` and an already-pushed tag, returning `HTTP 422 Validation Failed: target_commitish is invalid`. Now drops `--target` and discovers the previous release via `gh api .../releases/latest` for `--notes-start-tag` instead of hardcoding `v1.31.2`.
3. CHANGELOG: promote `[Unreleased]` to `[1.31.3]` since the version is actually shipped (Docker Hub `heavygee/hello-dalle-discordbot:1.31.3` + `:latest` pushed today, GitHub release published, git tag pushed).

## Test plan

- [x] CI gate (`ci`) green on this PR
- [ ] Next manual-publish dispatch creates tag + release without operator intervention (acceptance: green run end-to-end)

Made with [Cursor](https://cursor.com)