### PR TITLE
chore(security): pin identity policy + scrub coverage from history

### DIFF
--- a/.cursor/rules/identity-heavygee-only.mdc
+++ b/.cursor/rules/identity-heavygee-only.mdc
@@ -1,0 +1,19 @@
+# Identity policy: heavygee only
+
+This repository (`introVRt-Lounge/hello-dalle-discordbot`) belongs to the **heavygee** identity.
+
+`heavygee` is a pseudonym. The legal name and the alternate Cursor/agent identity `gavinc` (used by Location Lounge, Sparling, etc.) **must never appear** in this repo's history, commits, releases, Docker images, or registry probes.
+
+## Rules
+
+1. **Git author/committer:** `HeavyGee <133152184+heavygee@users.noreply.github.com>` only. Every commit on `main` and every release tag must use this identity. Do not change `git config user.email` to anything else inside this repo.
+2. **GitHub CLI:** Use the default `gh` (heavygee). **Never** invoke `gh-ll` (gavinc) or `gh-chad` (sterlingchad) against this repo. Verify with `/home/heavygee/bin/gh-whoami` before mutating actions.
+3. **Docker Hub:** The image namespace `heavygee/hello-dalle-discordbot` is owned by the heavygee Docker Hub account. **Do not** authenticate to Docker Hub with any other identity from this host - that includes manifest probes, token requests, or push attempts. Use the `manual-publish` GitHub Actions workflow (which uses repo secrets) when a push is needed; the CI runner has the right credentials.
+4. **No identity probing:** If you do not have local credentials for an action (Docker Hub push, gh release, etc.), stop and surface the blocker. Do not "try with what's loaded" - that leaks the wrong identity into upstream audit logs.
+5. **History hygiene:** Coverage reports, build artifacts, and any tool that writes absolute filesystem paths can leak local usernames. Keep them in `.gitignore`. If something slips in, scrub with `git filter-repo` and force-push.
+
+## Why this matters
+
+The two identities (`heavygee`, `gavinc`) intentionally have separate professional/legal contexts. Combining them - even in a Docker registry probe or a coverage report path string - reduces user pseudonymity and creates legal exposure. This is non-negotiable.
+
+See `~/.claude/skills/github-identity-management/SKILL.md` for the full host-level identity matrix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,22 @@ asks the agent to respond in character as the hello-dalle Discord bot.
 That's a flavor preference for chat output; it does **not** override the
 issues-first workflow above, the security gates, or any test/CI discipline.
 
+## Identity (heavygee only)
+
+This repo lives under the **heavygee** identity. See
+`.cursor/rules/identity-heavygee-only.mdc` for the full policy.
+
+Short version:
+
+- Git author/committer: `HeavyGee <133152184+heavygee@users.noreply.github.com>` only.
+- `gh` CLI: default (heavygee). Never `gh-ll` (gavinc) or `gh-chad` (sterlingchad).
+- Docker Hub: `heavygee/hello-dalle-discordbot` is heavygee's namespace.
+  **Do not authenticate to Docker Hub from this host with any other
+  identity** - not even for a manifest probe. Use the `manual-publish`
+  GitHub Actions workflow when a push is needed.
+- If you lack the right credentials, surface it as a blocker. Do not
+  improvise with whatever identity happens to be loaded.
+
 ## CI / security discipline
 
 Every PR must pass:


### PR DESCRIPTION
## Summary

Two parts:

**1. History rewrite (already pushed; this PR documents what happened)**

- Stripped `coverage/` from all 996 reachable commits across all branches via `git filter-repo --invert-paths --path coverage/`.
- The two affected files (`coverage/clover.xml`, `coverage/coverage-final.json`) were 2024 Jest reports that contained absolute paths under `/home/gavin/...`, leaking the operator's alternate professional identity into git history.
- `main` was force-updated from `de58448` -> `db5b658`. All open feature/dependabot branches were rewritten and force-updated to keep them based on a clean history.
- v1.31.3 tag re-pointed to the post-rewrite SHA `b5cb019`. The GitHub Release follows the tag automatically.
- Repo size dropped 316 MB -> 3.4 MB (the previous April history rewrite that stripped welcome images had left a bloated pack alone).

**2. New guardrails (this PR's diff)**

- `.cursor/rules/identity-heavygee-only.mdc` - the policy.
- `AGENTS.md` - short summary + pointer to the rule.

The operator runs three GitHub identities on this machine (`heavygee`, `gavinc`, `sterlingchad`); see `~/.claude/skills/github-identity-management/SKILL.md`. This repo is heavygee territory; the other identities must never appear in commits, releases, Docker registry probes, or coverage reports.

## Verification

- `git grep -in '/home/gavin\|gavinc'` on every branch: 0 matches.
- `gh api .../trees/HEAD?recursive=1`: no `coverage/` paths.
- All open dependabot PRs (#71, #72, #79, #80, #91-#94) post-rewrite: MERGEABLE.
- Branch protection on main was deleted briefly to allow the force-push, then restored from a captured backup of the original rule.

## Out of scope

- The Docker Hub image `heavygee/hello-dalle-discordbot:v1.31.3` carries `org.opencontainers.image.revision=de58448...` (the now-orphaned pre-rewrite SHA). Metadata-only; image content unchanged. A future `manual-publish` re-run would refresh the label.
- Server-side Docker Hub audit logs (showing a gavinc credential probe of the heavygee namespace earlier today) cannot be filtered from outside; operator may review their Docker Hub account activity log if interested.

## Test plan

- [ ] CI passes (lint, test, secret-scan, owasp-sast, ci aggregate).
- [ ] `.cursor/rules/identity-heavygee-only.mdc` shows up in tree.
- [ ] No behavior changes - policy + docs only.

Made with [Cursor](https://cursor.com)