### PR TITLE
chore(quality): address pending bot findings + fix broken lint-staged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/generate-pfp-transformations.cjs
+++ b/generate-pfp-transformations.cjs
@@ -5,7 +5,6 @@ const fs = require('fs');
 
 // Import compiled services
 const { generateProfilePicture } = require('./dist/services/pfpService');
-const { getDEFAULT_ENGINE } = require('./dist/config');
 
 async function generatePFPTransformations() {
     console.log('🚀 Generating PFP Transformations...');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "npx tsc --noEmit --skipLibCheck"
+      "bash -c 'npx tsc --noEmit -p tsconfig.check.json'"
     ]
   },
   "keywords": [],

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Guild, GuildMember, Message, CommandInteraction, ChatInputCommandInteraction } from 'discord.js';
+import { Client, GatewayIntentBits, Guild, GuildMember, Message, ChatInputCommandInteraction } from 'discord.js';
 import {
     welcomeCommand,
     welcomeNewMember,

--- a/src/commands/engine.ts
+++ b/src/commands/engine.ts
@@ -1,5 +1,5 @@
 import { Client, ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
-import { getDEFAULT_ENGINE, setDEFAULT_ENGINE, ImageEngine, BOT_USER_ROLE } from '../config';
+import { setDEFAULT_ENGINE, ImageEngine, BOT_USER_ROLE } from '../config';
 
 // Check if user has permission to use engine command
 function hasEnginePermission(member: any): boolean {

--- a/src/commands/pfp.ts
+++ b/src/commands/pfp.ts
@@ -1,4 +1,4 @@
-import { Client, CommandInteraction, PermissionsBitField, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { Client, PermissionsBitField, ChatInputCommandInteraction, GuildMember } from 'discord.js';
 import { generateProfilePicture } from '../services/pfpService';
 import { cooldownService } from '../services/cooldownService';
 import { logMessage } from '../utils/log';

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -2,6 +2,7 @@ import { DEBUG, OPENAI_API_KEY, WATERMARK_PATH, ImageEngine, getDEFAULT_ENGINE }
 import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
+import { pipeline } from 'stream/promises';
 import sharp = require('sharp');
 import { generateImageWithGemini, GeminiImageModelType } from '../services/geminiService';
 
@@ -315,14 +316,12 @@ export async function downloadAndSaveImage(url: string, filepath: string): Promi
         responseType: 'stream'
     });
 
-    return new Promise((resolve, reject) => {
-        response.data.pipe(fs.createWriteStream(filepath))
-            .on('finish', () => resolve(filepath))
-            .on('error', (e: unknown) => {
-                const errorMessage = e instanceof Error ? e.message : String(e);
-                reject(new Error(errorMessage));
-            });
-    });
+    // stream.pipeline propagates errors from BOTH the axios source stream
+    // and the writable target, and ensures the destination is closed on error
+    // (the previous .pipe()...on('error') only listened on the destination,
+    // so a network drop on the source stream produced an unhandled rejection).
+    await pipeline(response.data, fs.createWriteStream(filepath));
+    return filepath;
 }
 
 // Function to handle welcome image generation with watermark


### PR DESCRIPTION
## Summary

Audit of GitHub quality-bot output across recent PRs found everything in PR review threads RESOLVED, but six underlying findings the diffs didn't actually fix - plus a broken `lint-staged` config surfaced while addressing them.

### Quality-bot follow-ups

| # | File | Source | Finding |
|---|------|--------|---------|
| 1 | `.github/workflows/release.yml:11` | CodeQL alert #5 (open since 2025-10-29) | `test` job missing workflow `permissions:` block |
| 2 | `src/utils/imageUtils.ts:317-323` | github-code-quality on PR #97 | `axios` stream pipe with no source-side error handler |
| 3 | `src/bot.ts:1` | github-code-quality on PR #97 | Unused import `CommandInteraction` |
| 4 | `src/commands/pfp.ts:1` | github-code-quality on PR #97 | Unused import `CommandInteraction` |
| 5 | `src/commands/engine.ts:2` | github-code-quality on PR #97 | Unused import `getDEFAULT_ENGINE` |
| 6 | `generate-pfp-transformations.cjs:8` | github-code-quality on PR #97 | Unused require `getDEFAULT_ENGINE` |

#2 has runtime impact: the previous `.pipe()...on('error')` only fired for destination errors. Axios source-stream errors (network drops, mid-download DNS failures) became unhandled promise rejections; on Node 22 that's a process-killer by default. `stream.pipeline()` propagates errors from both ends and closes the destination cleanly. Worth fixing.

#3-#6 are dead-import cleanups. No behavior change.

#1 closes the last open CodeQL alert on the repo.

### Bonus: broken lint-staged hook

While committing this PR, the husky pre-commit fired and bombed on a pre-existing `MapIterator` iteration in `cooldownService.ts:158` that compiles fine under the project's actual `tsconfig.check.json` (target ES2020).

Root cause: `lint-staged` was running:

```
npx tsc --noEmit --skipLibCheck
```

with staged file paths injected as args. **`tsc` silently ignores `tsconfig.json` when given file args**, falling back to default ES3/ES5 settings - which then trip on any ES2020+ idiom anywhere in the dep graph.

Fixed by wrapping in `bash -c '...'` so file args don't reach tsc and the project config is loaded:

```
bash -c 'npx tsc --noEmit -p tsconfig.check.json'
```

This is why all PRs since this hook was added have been silently pushing through false positives or working around it. It now does what it claims to do.

## Verification

- [x] `npx tsc --noEmit -p tsconfig.check.json` clean
- [x] `npm test` -> 10 suites, 51 pass, 4 skipped (unchanged)
- [x] husky pre-commit ran and passed against this commit
- [ ] CI gates green
- [ ] CodeQL re-runs and closes alert #5 after merge

Made with [Cursor](https://cursor.com)