### PR TITLE
docs(repo): flag GEMINI_API_KEY rotation as outstanding + log dev-alert dismissals

### DIFF
--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -127,3 +127,11 @@ Record any change that is not in a PR (UI-only toggles, gh api flips, etc.):
 | 2026-06-04 | Replaced `release.yml` (broken semantic-release) with `docker-latest.yml` + `manual-publish.yml` | bot session | PR chore/ci-release-rework |
 | 2026-06-04 | Added F-lite `security-audit` job to `ci.yml` | bot session | PR chore/ci-release-rework |
 | 2026-06-04 | Flipped required status check from `test` to `ci` aggregate | bot session | gh api branch protection |
+| 2026-06-04 | Dismissed 19 dev-only Dependabot alerts (jest / semantic-release transitives) as `tolerable_risk` | bot session | gh api dependabot/alerts |
+| 2026-06-04 | Resolved secret-scanning alert #1 (Google API Key in test-gemini.js, leak commit unreachable) as `wont_fix` | bot session | gh api secret-scanning/alerts |
+
+## Outstanding operator actions
+
+- **Verify GEMINI_API_KEY rotation.** Secret-scanning alert #1 fired on 2025-11-01 for a Google API Key committed in `test-gemini.js` / `test-gemini-image.js` at commit `68da77c`. The files and commit are no longer reachable from any branch, so the repo side is clean and the alert was resolved as `wont_fix`. **The bot agent cannot verify whether the leaked key value was rotated.** If you didn't rotate when the alert opened, do it now: Google Cloud Console -> APIs & Services -> Credentials -> regenerate or restrict the API key, then update the bot's `GEMINI_API_KEY` env var on Coolify. If you already rotated, no further action needed.
+- **Upload `.github/social-preview.png`** via Settings -> General -> Social preview (no public API for the OG image).
+- **(Optional) Sponsorships** - decide on GitHub Sponsors / Ko-fi / skip; if yes, follow the ritual in the Sponsorships section above.


### PR DESCRIPTION
Records the 2026-06-04 batch of out-of-band actions in `REPO_SETTINGS.md`:

- 19 dev-only Dependabot alert dismissals (jest / semantic-release transitives, `tolerable_risk`)
- Secret-scanning alert #1 resolved as `wont_fix` (leak commit unreachable from any branch)
- The branch-protection check flip from `test` to `ci`

Also calls out the **one outstanding security item the agent cannot complete**: confirming the leaked GEMINI_API_KEY value was rotated in Google Cloud Console. The repo-side cleanup is done (commit 68da77c is unreachable, files are gone), but only the operator can verify the key was rotated at the source.

Made with [Cursor](https://cursor.com)