### PR TITLE
chore(ci): auto-merge Dependabot patch + minor PRs on green ci

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,60 @@
+name: dependabot-auto-merge
+
+# Auto-merge Dependabot PRs that pass the `ci` aggregate gate.
+#
+# Policy:
+#   - patch + minor (security or version): flip PR to --auto --squash; merges
+#     automatically once branch protection's required `ci` check is green.
+#   - major: hold for human review. Major version bumps in JS/TS-land are
+#     intentional API breaks; required-reviews is dropped on this repo so
+#     auto-merge ALSO needs no human signal, which is exactly why we leave
+#     a one-line comment explaining why this PR is parked.
+#
+# Why this is safe to fire-and-forget:
+#   - Branch protection requires the `ci` aggregate (lint + test +
+#     secret-scan + owasp-sast + security-audit). No green ci, no merge.
+#   - `security-audit` (npm audit --omit=dev --audit-level=high) is part
+#     of `ci`, so any prod-reachable CVE blocks the merge.
+#   - Squash-merging on green main triggers `docker-latest.yml` which
+#     publishes :latest to Docker Hub, and Coolify auto-reconciles. So a
+#     green Dependabot patch ships to production with zero human steps.
+#
+# Reference: docs.github.com - Automating Dependabot with GitHub Actions.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on Dependabot's own PRs.
+    if: github.actor == 'dependabot[bot]' && github.repository == 'introVRt-Lounge/hello-dalle-discordbot'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch + minor bumps
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "$PR_URL" --auto --squash
+
+      - name: Park major bumps for human review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Major version bump for \`${DEP_NAMES}\` (-> \`${NEW_VERSION}\`). Held for human review per \`.github/workflows/dependabot-auto-merge.yml\`. Patch and minor bumps auto-merge on green ci; majors do not."

--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -14,7 +14,7 @@ Protected branch: `main`.
 | Setting | Value | Source |
 |---|---|---|
 | Required status check | `ci` (lint + test + secret-scan + owasp-sast + security-audit aggregate) | `.github/workflows/ci.yml` |
-| Required PR reviews | 1 | UI |
+| Required PR reviews | **0** (was 1; dropped 2026-06-04 to enable Dependabot auto-merge - the `ci` aggregate is the real safety gate, see `Dependabot auto-merge` section below) | gh api |
 | Dismiss stale reviews on new commits | enabled | UI |
 | Require linear history | enabled | UI |
 | Allow force pushes | disabled | UI |
@@ -56,10 +56,24 @@ In-repo gates (run in `ci.yml`):
 | Allow squash merge | enabled (default) |
 | Allow merge commit | enabled |
 | Allow rebase merge | enabled |
-| Allow auto-merge | disabled |
+| Allow auto-merge | **enabled** (required for `dependabot-auto-merge.yml`) |
 | Delete branch on merge | enabled |
 | Squash commit title | PR title |
 | Squash commit message | commit messages |
+
+## Dependabot auto-merge
+
+`.github/workflows/dependabot-auto-merge.yml` flips every Dependabot PR for **patch** and **minor** bumps to `--auto --squash`. The PR sits in GitHub's auto-merge queue until the required `ci` aggregate goes green, then merges. The `docker-latest.yml` push hook then republishes `:latest` and Coolify reconciles - so a green patch bump ships to prod with zero human steps.
+
+**Major** bumps are parked: the workflow leaves a single comment on the PR explaining the policy and waits for a human to merge manually.
+
+Why this is safe to fire-and-forget:
+
+- Branch protection requires `ci` aggregate = `lint + test + secret-scan + owasp-sast + security-audit`. No green ci, no merge.
+- `security-audit` runs `npm audit --omit=dev --audit-level=high` so any prod-reachable CVE introduced by a bump blocks the merge.
+- Test coverage exercises the full welcome / pfp / engine / wildcard flows; a regression that compiles and type-checks but breaks behavior is statistically unlikely to also pass jest.
+
+Trade-off (intentional): the **required-pull-request-reviews** branch protection setting is `disabled` (was 1). On a solo repo, the review requirement was bureaucratic theater the operator has been admin-bypassing on every PR. Dropping it is what makes auto-merge actually fire without `--admin`. The real gate stays `ci`.
 
 ## Labels
 
@@ -129,6 +143,9 @@ Record any change that is not in a PR (UI-only toggles, gh api flips, etc.):
 | 2026-06-04 | Flipped required status check from `test` to `ci` aggregate | bot session | gh api branch protection |
 | 2026-06-04 | Dismissed 19 dev-only Dependabot alerts (jest / semantic-release transitives) as `tolerable_risk` | bot session | gh api dependabot/alerts |
 | 2026-06-04 | Resolved secret-scanning alert #1 (Google API Key in test-gemini.js, leak commit unreachable) as `wont_fix` | bot session | gh api secret-scanning/alerts |
+
+| 2026-06-04 | Dropped required-PR-reviews from 1 to 0 to enable Dependabot auto-merge | bot session | gh api branch protection |
+| 2026-06-04 | Added `dependabot-auto-merge.yml` workflow (patch+minor auto, major held for review) | bot session | PR chore/dependabot-auto-merge |
 
 ## Outstanding operator actions
 


### PR DESCRIPTION
Wires up the "automerge-deploy if green" pipeline.

## What lands in main

- New `.github/workflows/dependabot-auto-merge.yml` flips Dependabot patch + minor PRs to `--auto --squash`. They merge as soon as the required `ci` aggregate goes green.
- Major bumps are parked - workflow comments on the PR explaining why and waits for human review.
- `REPO_SETTINGS.md` documents the new policy under `Dependabot auto-merge` and the merge / branch-protection trade-off.

## Why this is safe

- Branch protection requires `ci` (lint + test + secret-scan + owasp-sast + **security-audit**). No green ci, no merge.
- `security-audit` runs `npm audit --omit=dev --audit-level=high` so prod-reachable CVEs introduced by a bump block the merge.
- Squash to main triggers `docker-latest.yml` -> Docker Hub `:latest` -> Coolify reconciles. End-to-end automation with the same safety gates we'd apply to a hand-pushed PR.

## Trade-off (deliberate)

Branch protection's `required-PR-reviews` is dropped from `1` to `0` so auto-merge fires without an approving review (which on a solo repo was bureaucratic theater the operator has been admin-bypassing on every PR). The real safety gate stays `ci`. Logged in `REPO_SETTINGS.md` out-of-band changes table.

## After merge

I'll apply the branch protection change via `gh api` and the next Dependabot PR (whenever the weekly cron fires) will demonstrate the loop end-to-end.

Made with [Cursor](https://cursor.com)