### PR TITLE
chore(ci): ntfy push alerts on production-impacting failures

### DIFF
--- a/.github/actions/ntfy/action.yml
+++ b/.github/actions/ntfy/action.yml
@@ -1,0 +1,80 @@
+name: ntfy
+description: Post a notification to ntfy. No-op if NTFY_URL secret is not set.
+
+inputs:
+  url:
+    description: Full ntfy topic URL (e.g. https://ntfy.example.com/my-topic). Pass via secrets.NTFY_URL.
+    required: true
+  token:
+    description: ntfy bearer token. Pass via secrets.NTFY_TOKEN.
+    required: false
+    default: ''
+  title:
+    description: Short title for the notification.
+    required: true
+  message:
+    description: Body of the notification.
+    required: true
+  priority:
+    description: ntfy priority (min/low/default/high/urgent or 1-5). Defaults to default.
+    required: false
+    default: 'default'
+  tags:
+    description: Comma-separated emoji shortcodes (e.g. warning,octocat).
+    required: false
+    default: 'warning'
+  click:
+    description: URL to open when the notification is tapped (typically the workflow run URL).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Post to ntfy
+      shell: bash
+      env:
+        NTFY_URL: ${{ inputs.url }}
+        NTFY_TOKEN: ${{ inputs.token }}
+        NTFY_TITLE: ${{ inputs.title }}
+        NTFY_MESSAGE: ${{ inputs.message }}
+        NTFY_PRIORITY: ${{ inputs.priority }}
+        NTFY_TAGS: ${{ inputs.tags }}
+        NTFY_CLICK: ${{ inputs.click }}
+      run: |
+        set -uo pipefail
+        if [ -z "${NTFY_URL:-}" ]; then
+          echo "::warning::NTFY_URL not configured; skipping ntfy post"
+          exit 0
+        fi
+
+        AUTH_HEADER=()
+        if [ -n "${NTFY_TOKEN:-}" ]; then
+          AUTH_HEADER=(-H "Authorization: Bearer ${NTFY_TOKEN}")
+        fi
+
+        CLICK_HEADER=()
+        if [ -n "${NTFY_CLICK:-}" ]; then
+          CLICK_HEADER=(-H "Click: ${NTFY_CLICK}")
+        fi
+
+        # ntfy headers don't accept newlines; collapse to single line for the
+        # title and message and let the body carry full detail when needed.
+        TITLE_FLAT="$(printf '%s' "$NTFY_TITLE" | tr '\n\r' '  ')"
+
+        HTTP_CODE=$(curl -sS --max-time 15 -o /tmp/ntfy-response.txt -w '%{http_code}' \
+          "${AUTH_HEADER[@]}" \
+          -H "Title: ${TITLE_FLAT}" \
+          -H "Priority: ${NTFY_PRIORITY}" \
+          -H "Tags: ${NTFY_TAGS}" \
+          "${CLICK_HEADER[@]}" \
+          -d "${NTFY_MESSAGE}" \
+          "${NTFY_URL}" || echo "curl-failed")
+
+        if [ "$HTTP_CODE" = "curl-failed" ] || [ "${HTTP_CODE:0:1}" != "2" ]; then
+          echo "::warning::ntfy publish returned ${HTTP_CODE}"
+          cat /tmp/ntfy-response.txt 2>/dev/null | head -5 || true
+          # Do not fail the parent workflow just because the alert post failed.
+          exit 0
+        fi
+        echo "ntfy publish ok (${HTTP_CODE})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,23 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed."
+
+      # Only ping on push to main (red main = production blocker; PR failures
+      # are visible in the PR UI and don't need a push notification).
+      - name: Checkout for ntfy action
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/checkout@v6
+      - name: Notify ntfy on main failure
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/ntfy
+        with:
+          url: ${{ secrets.NTFY_URL }}
+          token: ${{ secrets.NTFY_TOKEN }}
+          title: "ci red on main: ${{ github.repository }}"
+          message: |
+            lint=${{ needs.lint.result }} test=${{ needs.test.result }} secret-scan=${{ needs.secret-scan.result }} owasp-sast=${{ needs.owasp-sast.result }} security-audit=${{ needs.security-audit.result }}
+            commit ${{ github.sha }}
+            by ${{ github.actor }}
+          priority: high
+          tags: rotating_light,octocat
+          click: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,6 +33,9 @@ jobs:
     # Only act on Dependabot's own PRs.
     if: github.actor == 'dependabot[bot]' && github.repository == 'introVRt-Lounge/hello-dalle-discordbot'
     steps:
+      - name: Checkout (for local composite actions)
+        uses: actions/checkout@v6
+
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v2
@@ -58,3 +61,17 @@ jobs:
         run: |
           gh pr comment "$PR_URL" --body \
             "Major version bump for \`${DEP_NAMES}\` (-> \`${NEW_VERSION}\`). Held for human review per \`.github/workflows/dependabot-auto-merge.yml\`. Patch and minor bumps auto-merge on green ci; majors do not."
+
+      - name: Notify ntfy when a major is parked
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        uses: ./.github/actions/ntfy
+        with:
+          url: ${{ secrets.NTFY_URL }}
+          token: ${{ secrets.NTFY_TOKEN }}
+          title: "Dependabot major bump parked - review needed"
+          message: |
+            ${{ steps.meta.outputs.dependency-names }} -> ${{ steps.meta.outputs.new-version }}
+            PR ${{ github.event.pull_request.number }} on ${{ github.repository }}
+          priority: low
+          tags: package,octocat
+          click: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -84,3 +84,17 @@ jobs:
             echo ""
             echo "Coolify watches :latest and will pull on next reconcile."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify ntfy on failure
+        if: failure()
+        uses: ./.github/actions/ntfy
+        with:
+          url: ${{ secrets.NTFY_URL }}
+          token: ${{ secrets.NTFY_TOKEN }}
+          title: "docker-latest failed: production deploy stalled"
+          message: |
+            docker-latest.yml failed on commit ${{ github.sha }} (${{ github.actor }}).
+            Coolify will keep serving the previous :latest until this is fixed.
+          priority: urgent
+          tags: rotating_light,whale,octocat
+          click: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -146,3 +146,17 @@ jobs:
             echo "- GitHub release: \`${CREATE_RELEASE}\`"
             echo "- Commit: \`${GITHUB_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify ntfy on failure
+        if: failure()
+        uses: ./.github/actions/ntfy
+        with:
+          url: ${{ secrets.NTFY_URL }}
+          token: ${{ secrets.NTFY_TOKEN }}
+          title: "manual-publish ${{ inputs.tag }} failed"
+          message: |
+            Operator-triggered manual SemVer publish of ${{ inputs.tag }} failed on commit ${{ github.sha }}.
+            Image was NOT pushed to Docker Hub. Re-run after fixing the cause.
+          priority: high
+          tags: rotating_light,whale,bookmark
+          click: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -65,15 +65,42 @@ In-repo gates (run in `ci.yml`):
 
 `.github/workflows/dependabot-auto-merge.yml` flips every Dependabot PR for **patch** and **minor** bumps to `--auto --squash`. The PR sits in GitHub's auto-merge queue until the required `ci` aggregate goes green, then merges. The `docker-latest.yml` push hook then republishes `:latest` and Coolify reconciles - so a green patch bump ships to prod with zero human steps.
 
-**Major** bumps are parked: the workflow leaves a single comment on the PR explaining the policy and waits for a human to merge manually.
+**Major** bumps are parked: the workflow leaves a single comment on the PR explaining the policy, fires a low-priority ntfy notification (so the operator knows a PR is parked), and waits for a human to merge manually.
 
 Why this is safe to fire-and-forget:
 
 - Branch protection requires `ci` aggregate = `lint + test + secret-scan + owasp-sast + security-audit`. No green ci, no merge.
 - `security-audit` runs `npm audit --omit=dev --audit-level=high` so any prod-reachable CVE introduced by a bump blocks the merge.
 - Test coverage exercises the full welcome / pfp / engine / wildcard flows; a regression that compiles and type-checks but breaks behavior is statistically unlikely to also pass jest.
+- Failure-mode alerting via ntfy (see below) catches the long tail.
 
 Trade-off (intentional): the **required-pull-request-reviews** branch protection setting is `disabled` (was 1). On a solo repo, the review requirement was bureaucratic theater the operator has been admin-bypassing on every PR. Dropping it is what makes auto-merge actually fire without `--admin`. The real gate stays `ci`.
+
+## Failure-mode alerts (ntfy)
+
+Failure pings post to the homestack ntfy at `https://ntfy.introvrtlounge.com/hello-dalle-discordbot`.
+
+Subscribe on phone / desktop:
+```
+ntfy subscribe https://ntfy.introvrtlounge.com/hello-dalle-discordbot
+```
+
+Or in the ntfy mobile app: add server `https://ntfy.introvrtlounge.com`, topic `hello-dalle-discordbot`, with the `hello-dalle-publisher` token.
+
+| Event | Workflow | Priority |
+|---|---|---|
+| `ci` red on `main` (push, not PR) | `ci.yml` | high |
+| `docker-latest` failed (production deploy stalled) | `docker-latest.yml` | urgent |
+| `manual-publish` failed (operator-triggered SemVer cut) | `manual-publish.yml` | high |
+| Dependabot major-version bump parked | `dependabot-auto-merge.yml` | low |
+
+PR-stage CI failures do **not** ping (the PR UI already surfaces them; auto-merge will simply not fire for that PR).
+
+The shared posting logic lives in `.github/actions/ntfy/action.yml`. It is a pure-bash composite action that no-ops gracefully if `secrets.NTFY_URL` is not configured (so the workflows stay portable / fork-safe).
+
+Secrets: `NTFY_URL` + `NTFY_TOKEN` are stored in **both** the Actions and Dependabot secret namespaces (Dependabot-triggered workflows can't read regular Actions secrets, see GitHub docs).
+
+ntfy server-side: a dedicated `hello-dalle-publisher` user with `write-only` access to topic `hello-dalle-discordbot` (mirrors the `mapsnatch-publisher` convention on the same homestack). Two access tokens are issued, labelled `github-actions-hello-dalle` (Actions context) and `github-actions-hello-dalle-dependabot` (Dependabot context). To rotate: `docker exec ntfy ntfy token remove <prefix>` then re-mint and `gh secret set NTFY_TOKEN --app {actions,dependabot} --repo introVRt-Lounge/hello-dalle-discordbot --body <new>`.
 
 ## Labels
 
@@ -146,6 +173,7 @@ Record any change that is not in a PR (UI-only toggles, gh api flips, etc.):
 
 | 2026-06-04 | Dropped required-PR-reviews from 1 to 0 to enable Dependabot auto-merge | bot session | gh api branch protection |
 | 2026-06-04 | Added `dependabot-auto-merge.yml` workflow (patch+minor auto, major held for review) | bot session | PR chore/dependabot-auto-merge |
+| 2026-06-04 | Provisioned ntfy publisher (user `hello-dalle-publisher`, topic `hello-dalle-discordbot`, write-only) on `ntfy.introvrtlounge.com` and wired failure pings into ci/docker-latest/manual-publish/dependabot-auto-merge | bot session | PR chore/ntfy-failure-alerts |
 
 ## Outstanding operator actions
 


### PR DESCRIPTION
Phone-buzz alerting on the events that actually matter, in lieu of a runtime smoke test (cheaper to maintain, signals as fast or faster).

## What lands in main

- New `.github/actions/ntfy/action.yml` composite action - pure-bash ntfy POST logic with graceful no-op when `NTFY_URL` is unset.
- Failure ping wired into:
  - `ci.yml` - high priority, only on push to main (PR failures already visible in the PR UI)
  - `docker-latest.yml` - urgent priority (production deploy stalled)
  - `manual-publish.yml` - high priority (operator-triggered SemVer cut failed)
  - `dependabot-auto-merge.yml` - low priority (major bump parked for human review)
- `REPO_SETTINGS.md` documents the event matrix, subscribe command, and secret-rotation procedure under `Failure-mode alerts (ntfy)`.

## Server-side wiring (already provisioned)

- ntfy server: `https://ntfy.introvrtlounge.com` (homestack, behind Traefik)
- Topic: `hello-dalle-discordbot`
- Publisher user: `hello-dalle-publisher` (write-only, mirroring `mapsnatch-publisher` convention)
- Two tokens issued and stored as secrets:
  - `NTFY_URL` + `NTFY_TOKEN` in the **Actions** namespace (for ci/docker-latest/manual-publish)
  - `NTFY_URL` + `NTFY_TOKEN` in the **Dependabot** namespace (for dependabot-auto-merge - dependabot-triggered workflows can't read regular Actions secrets)

## Subscribe

```
ntfy subscribe https://ntfy.introvrtlounge.com/hello-dalle-discordbot
```

Or in the ntfy mobile app: server `https://ntfy.introvrtlounge.com`, topic `hello-dalle-discordbot`, with the publisher token.

## Verification

YAML lints clean for all 5 changed files. The composite action is intentionally tolerant: a missing secret silently no-ops rather than failing the parent workflow.

Made with [Cursor](https://cursor.com)