### PR TITLE
fix(build): migrate tsconfig to moduleResolution:node16 for TypeScript 6

### DIFF
--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,28 +1,23 @@
 {
   "compilerOptions": {
-    // TypeScript config for DEVELOPMENT TYPE CHECKING (noEmit for fast checks)
-    "rootDir": "./src",          // Root directory for your source files
-    "outDir": "./dist",          // Output directory for compiled files
-    "baseUrl": ".",              // Base URL for module resolution (relative to project root)
-    "paths": {
-      "*": ["./src/*"]           // Ensure path resolution is from the 'src' directory
-    },
-    "strict": true,              // Enable all strict type-checking options
-    "moduleResolution": "node",  // Use Node module resolution strategy
-    "target": "ES2020",          // Target JavaScript version (supports private identifiers)
-    "module": "commonjs",        // Module system
-    "resolveJsonModule": true,   // Enable .json modules
-    "esModuleInterop": true,     // Enable compatibility for ES module imports
-    "skipLibCheck": true,        // Skip type checking of declaration files
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "strict": true,
+    "moduleResolution": "node16",
+    "target": "ES2020",
+    "module": "node16",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": false,        // Don't generate .d.ts files for pre-commit checks
-    "noEmit": true               // Don't emit files, just check types (fast)
+    "declaration": false,
+    "noEmit": true
   },
   "include": [
-    "src/**/*.ts"                // Include all TypeScript files in the src directory
+    "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules"               // Exclude node_modules directory
+    "node_modules"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,23 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",          // Root directory for your source files
-    "outDir": "./dist",          // Output directory for compiled files
-    "baseUrl": ".",              // Base URL for module resolution (relative to project root)
-    "paths": {
-      "*": ["./src/*"]           // Ensure path resolution is from the 'src' directory
-    },
-    "strict": true,              // Enable all strict type-checking options
-    "moduleResolution": "node",  // Use Node module resolution strategy
-    "target": "ES2020",          // Target JavaScript version (supports private identifiers)
-    "module": "commonjs",        // Module system
-    "resolveJsonModule": true,   // Enable .json modules
-    "esModuleInterop": true,     // Enable compatibility for ES module imports
-    "skipLibCheck": true,        // Skip type checking of declaration files
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "strict": true,
+    "moduleResolution": "node16",
+    "target": "ES2020",
+    "module": "node16",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": false,        // Don't generate .d.ts files for pre-commit checks
-    "noEmit": false              // Emit compiled JavaScript files
+    "declaration": false,
+    "noEmit": false
   },
   "include": [
-    "src/**/*.ts"                // Include all TypeScript files in the src directory
+    "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules"               // Exclude node_modules directory
+    "node_modules"
   ]
 }


### PR DESCRIPTION
Unblocks dependabot PR #112 (TypeScript 5→6).

TypeScript 6.0 deprecated two options we were using:
- `TS5101`: `baseUrl` is deprecated with non-bundler moduleResolution
- `TS5107`: `moduleResolution: node` (renamed to `node10`) is deprecated

**Changes:**
- `moduleResolution: 'node' → 'node16'`
- `module: 'commonjs' → 'node16'` (required to match; emits CJS because `package.json` has no `type: module`)
- Remove `baseUrl` + `paths` — the `"*": ["./src/*"]` mapping was dead code (all non-relative imports are real npm packages, verified by grep)

**Applies to both** `tsconfig.json` and `tsconfig.check.json`.

**Verified locally:** `tsc --noEmit -p tsconfig.check.json` clean, jest 51 passed / 4 skipped.

Made with [Cursor](https://cursor.com)