### PR TITLE
fix(image): retry Gemini empty responses; use gpt-image-1 fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,20 @@ If you discover a leaked credential in any branch:
   current PR.
 - Pin Docker / GitHub Action versions instead of using floating tags.
 - Use `gh` (not curl + manual JSON) for GitHub API operations.
+
+## Production deployment (how code reaches Coolify)
+
+**AGENTS.md does not replace the runbooks below** — read them before
+touching deploy plumbing or claiming something is live.
+
+- **Step 1:** Merge (or push) to `main` with green `ci` aggregate
+- **Step 2:** `.github/workflows/docker-latest.yml` builds and pushes `heavygee/hello-dalle-discordbot:latest` (+ `:main-<sha>`) to Docker Hub
+- **Step 3:** Coolify (Bots project, service `hello-dalle` on `coolify.introvrtlounge.com`) watches `:latest` and reconciles the container on the next pull
+
+Canonical detail: [`REPO_SETTINGS.md`](./REPO_SETTINGS.md) (branch protection, auto-merge, ntfy alerts) and [`.github/workflows/docker-latest.yml`](.github/workflows/docker-latest.yml).
+
+**Do not** build or run production containers from this checkout. [`PRODUCTION_DEPLOYMENT.md`](./PRODUCTION_DEPLOYMENT.md) explains the dev/prod boundary (some Watchtower paths there are legacy; Coolify + `docker-latest.yml` is current per `REPO_SETTINGS.md`).
+
+Operator-triggered SemVer releases (optional): `.github/workflows/manual-publish.yml`.
+
+**Env vars** (e.g. `GEMINI_API_KEY`, `OPENAI_API_KEY`, `DEFAULT_ENGINE`, `OPENAI_IMAGE_MODEL`) are set in Coolify, not in this repo. Code changes alone do not rotate secrets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,18 +65,6 @@
         "undici": "^5.25.4"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
@@ -84,13 +72,13 @@
       "dev": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -99,29 +87,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -138,13 +128,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -154,13 +145,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -170,36 +162,39 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -218,9 +213,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -228,43 +223,47 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -496,32 +495,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -529,13 +529,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -546,6 +547,17 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -742,15 +754,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -2169,17 +2172,18 @@
       }
     },
     "node_modules/@jimp/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/file-ops": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/file-ops": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "await-to-js": "^3.0.0",
         "exif-parser": "^0.1.12",
-        "file-type": "^16.0.0",
+        "file-type": "^21.3.3",
         "mime": "3"
       },
       "engines": {
@@ -2187,14 +2191,15 @@
       }
     },
     "node_modules/@jimp/diff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
-      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+      "integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "pixelmatch": "^5.3.0"
       },
       "engines": {
@@ -2202,23 +2207,25 @@
       }
     },
     "node_modules/@jimp/file-ops": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
-      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+      "integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@jimp/js-bmp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
-      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+      "integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "bmp-ts": "^1.0.9"
       },
       "engines": {
@@ -2226,13 +2233,14 @@
       }
     },
     "node_modules/@jimp/js-gif": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
-      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+      "integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "gifwrap": "^0.10.1",
         "omggif": "^1.0.10"
       },
@@ -2241,13 +2249,14 @@
       }
     },
     "node_modules/@jimp/js-jpeg": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
-      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+      "integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "jpeg-js": "^0.4.4"
       },
       "engines": {
@@ -2255,13 +2264,14 @@
       }
     },
     "node_modules/@jimp/js-png": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
-      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+      "integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "pngjs": "^7.0.0"
       },
       "engines": {
@@ -2269,13 +2279,14 @@
       }
     },
     "node_modules/@jimp/js-tiff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
-      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+      "integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "utif2": "^4.1.0"
       },
       "engines": {
@@ -2283,13 +2294,14 @@
       }
     },
     "node_modules/@jimp/plugin-blit": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
-      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+      "integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2301,30 +2313,33 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-blur": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
-      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+      "integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/utils": "1.6.0"
+        "@jimp/core": "1.6.1",
+        "@jimp/utils": "1.6.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@jimp/plugin-circle": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
-      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+      "integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2336,19 +2351,21 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-color": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
-      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+      "integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "tinycolor2": "^1.6.0",
         "zod": "^3.23.8"
       },
@@ -2361,21 +2378,23 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-contain": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
-      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+      "integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2387,20 +2406,22 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-cover": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
-      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+      "integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2412,19 +2433,21 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-crop": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
-      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+      "integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2436,18 +2459,20 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-displace": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
-      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+      "integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2459,30 +2484,33 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-dither": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
-      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+      "integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0"
+        "@jimp/types": "1.6.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@jimp/plugin-fisheye": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
-      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+      "integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2494,17 +2522,19 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-flip": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
-      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+      "integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2516,25 +2546,27 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-hash": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
-      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+      "integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "any-base": "^1.1.0"
       },
       "engines": {
@@ -2542,12 +2574,13 @@
       }
     },
     "node_modules/@jimp/plugin-mask": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
-      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+      "integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2559,21 +2592,23 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-print": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
-      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+      "integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/types": "1.6.1",
         "parse-bmfont-ascii": "^1.0.6",
         "parse-bmfont-binary": "^1.0.6",
         "parse-bmfont-xml": "^1.1.6",
@@ -2589,15 +2624,17 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-quantize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
-      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+      "integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "image-q": "^4.0.0",
         "zod": "^3.23.8"
@@ -2611,18 +2648,20 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-resize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
-      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+      "integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2634,21 +2673,23 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-rotate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
-      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+      "integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2660,21 +2701,23 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-threshold": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
-      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+      "integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -2686,15 +2729,17 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/types": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
-      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+      "integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
       },
@@ -2707,17 +2752,19 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "tinycolor2": "^1.6.0"
       },
       "engines": {
@@ -3202,10 +3249,11 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
@@ -3498,11 +3546,30 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -4027,7 +4094,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -4088,6 +4156,7 @@
       "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
       "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4238,12 +4307,16 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -4255,7 +4328,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
       "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -4264,9 +4338,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4287,9 +4361,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -4305,12 +4379,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.19",
-        "caniuse-lite": "^1.0.30001751",
-        "electron-to-chromium": "^1.5.238",
-        "node-releases": "^2.0.26",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4377,9 +4452,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001751",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
-      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4394,7 +4469,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4822,10 +4898,21 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4882,9 +4969,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4955,10 +5043,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5094,10 +5183,11 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.242.tgz",
-      "integrity": "sha512-msZ7SYGFpXkm/iUizlMrm/FPNeYo8uSltQccLVFO3fV4RN2JWGdG7Aatztxtw3uDWp3DkupfkrosLjUnhY+iOw==",
-      "dev": true
+      "version": "1.5.381",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -5498,17 +5588,19 @@
       }
     },
     "node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -5617,15 +5709,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5777,6 +5870,7 @@
       "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
       "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "image-q": "^4.0.0",
         "omggif": "^1.0.10"
@@ -6027,13 +6121,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/image-q": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
       "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "16.9.1"
       }
@@ -6042,7 +6138,8 @@
       "version": "16.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -7463,10 +7560,11 @@
       }
     },
     "node_modules/jest-mock-axios/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8036,10 +8134,11 @@
       }
     },
     "node_modules/jest-mock-axios/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8603,10 +8702,11 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8850,38 +8950,39 @@
       }
     },
     "node_modules/jimp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
-      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+      "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/diff": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-gif": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-blur": "1.6.0",
-        "@jimp/plugin-circle": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-contain": "1.6.0",
-        "@jimp/plugin-cover": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-displace": "1.6.0",
-        "@jimp/plugin-dither": "1.6.0",
-        "@jimp/plugin-fisheye": "1.6.0",
-        "@jimp/plugin-flip": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/plugin-mask": "1.6.0",
-        "@jimp/plugin-print": "1.6.0",
-        "@jimp/plugin-quantize": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/plugin-rotate": "1.6.0",
-        "@jimp/plugin-threshold": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0"
+        "@jimp/core": "1.6.1",
+        "@jimp/diff": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-gif": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-blur": "1.6.1",
+        "@jimp/plugin-circle": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-contain": "1.6.1",
+        "@jimp/plugin-cover": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-displace": "1.6.1",
+        "@jimp/plugin-dither": "1.6.1",
+        "@jimp/plugin-fisheye": "1.6.1",
+        "@jimp/plugin-flip": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/plugin-mask": "1.6.1",
+        "@jimp/plugin-print": "1.6.1",
+        "@jimp/plugin-quantize": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/plugin-rotate": "1.6.1",
+        "@jimp/plugin-threshold": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1"
       },
       "engines": {
         "node": ">=18"
@@ -8891,7 +8992,8 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -8901,10 +9003,11 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -9366,6 +9469,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -9525,6 +9629,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -9677,10 +9782,14 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
-      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
-      "dev": true
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.2",
@@ -9732,15 +9841,16 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.6.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.6.2.tgz",
-      "integrity": "sha512-7iKzNfy8lWYs3zq4oFPa8EXZz5xt9gQNKJZau3B1ErLBb6bF7sBJ00x09485DOvRT2l5Gerbl3VlZNT57MxJVA==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
+        "@npmcli/metavuln-calculator",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
         "@npmcli/redact",
@@ -9751,7 +9861,6 @@
         "cacache",
         "chalk",
         "ci-info",
-        "cli-columns",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -9803,72 +9912,80 @@
         "which"
       ],
       "dev": true,
+      "license": "Artistic-2.0",
+      "workspaces": [
+        "docs",
+        "smoke-tests",
+        "mock-globals",
+        "mock-registry",
+        "workspaces/*"
+      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.6",
-        "@npmcli/config": "^10.4.2",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/package-json": "^7.0.1",
-        "@npmcli/promise-spawn": "^8.0.3",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^10.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "abbrev": "^3.0.1",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.1",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
-        "cli-columns": "^4.0.0",
+        "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^11.0.3",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
-        "ini": "^5.0.0",
-        "init-package-json": "^8.2.2",
-        "is-cidr": "^6.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
+        "hosted-git-info": "^9.0.3",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.9",
-        "libnpmexec": "^10.1.8",
-        "libnpmfund": "^7.0.9",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.9",
-        "libnpmpublish": "^11.1.2",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.2",
-        "make-fetch-happen": "^15.0.2",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.1",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.4.2",
-        "nopt": "^8.1.0",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.2",
-        "npm-package-arg": "^13.0.1",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-profile": "^12.0.0",
-        "npm-registry-fetch": "^19.0.0",
-        "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
-        "pacote": "^21.0.3",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "node-gyp": "^12.4.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.1",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^21.5.1",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
-        "semver": "^7.7.3",
+        "read": "^5.0.1",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.1",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.2",
-        "which": "^5.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -9890,92 +10007,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -9997,7 +10035,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10013,42 +10051,43 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.6",
+      "version": "9.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/map-workspaces": "^5.0.0",
         "@npmcli/metavuln-calculator": "^9.0.2",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.0",
-        "bin-links": "^5.0.0",
+        "bin-links": "^6.0.0",
         "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
         "lru-cache": "^11.2.1",
         "minimatch": "^10.0.3",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.0",
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
         "pacote": "^21.0.2",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
         "semver": "^7.3.7",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "treeverse": "^3.0.0",
         "walk-up-path": "^4.0.0"
       },
@@ -10060,7 +10099,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.2",
+      "version": "10.11.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10068,9 +10107,9 @@
         "@npmcli/map-workspaces": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
-        "ini": "^5.0.0",
-        "nopt": "^8.1.0",
-        "proc-log": "^5.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "walk-up-path": "^4.0.0"
       },
@@ -10079,7 +10118,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10087,53 +10126,53 @@
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
         "lru-cache": "^11.2.1",
         "npm-pick-manifest": "^11.0.1",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "bin": {
         "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "5.0.0",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/name-from-folder": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
-        "glob": "^11.0.3",
+        "glob": "^13.0.0",
         "minimatch": "^10.0.3"
       },
       "engines": {
@@ -10141,15 +10180,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^20.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
         "pacote": "^21.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -10157,55 +10196,55 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "7.0.1",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^7.0.0",
-        "glob": "^11.0.3",
+        "glob": "^13.0.0",
         "hosted-git-info": "^9.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.3",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10213,43 +10252,32 @@
         "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.2.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^11.0.0",
-        "proc-log": "^5.0.0",
-        "which": "^5.0.0"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
       "engines": {
-        "node": ">=14"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
@@ -10265,7 +10293,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10274,7 +10302,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10283,43 +10311,43 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
+        "tuf-js": "^4.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -10336,40 +10364,25 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/agent-base": {
@@ -10379,27 +10392,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/aproba": {
@@ -10415,25 +10407,28 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
@@ -10449,31 +10444,33 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.1",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^11.0.3",
+        "glob": "^13.0.0",
         "lru-cache": "^11.1.0",
         "minipass": "^7.0.3",
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "unique-filename": "^4.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10501,7 +10498,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -10516,96 +10513,30 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.1",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "5.0.0"
-      },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/cssesc": {
@@ -10638,34 +10569,12 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -10677,14 +10586,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
@@ -10696,22 +10599,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/fs-minipass": {
@@ -10727,23 +10614,17 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "11.0.3",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10756,7 +10637,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10800,7 +10681,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10810,6 +10691,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
@@ -10824,44 +10709,34 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/npm/node_modules/ini": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "8.2.2",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/package-json": "^7.0.0",
         "npm-package-arg": "^13.0.0",
-        "promzard": "^2.0.0",
-        "read": "^4.0.0",
+        "promzard": "^3.0.1",
+        "read": "^5.0.1",
         "semver": "^7.7.2",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^6.0.2"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10869,70 +10744,34 @@
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/isexe": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
@@ -10979,13 +10818,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.9",
+      "version": "8.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.6",
-        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
         "minimatch": "^10.0.3",
@@ -10998,20 +10837,20 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.8",
+      "version": "10.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.6",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "read": "^4.0.0",
+        "proc-log": "^6.0.0",
+        "read": "^5.0.1",
         "semver": "^7.3.7",
         "signal-exit": "^4.1.0",
         "walk-up-path": "^4.0.0"
@@ -11021,12 +10860,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.9",
+      "version": "7.0.24",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.6"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11046,12 +10885,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.9",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.6",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -11061,7 +10900,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.2",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11070,10 +10909,10 @@
         "ci-info": "^4.0.0",
         "npm-package-arg": "^13.0.0",
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7",
         "sigstore": "^4.0.0",
-        "ssri": "^12.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11105,15 +10944,15 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -11121,56 +10960,57 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.2",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.0.3",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -11188,44 +11028,32 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -11252,25 +11080,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -11295,12 +11117,12 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/negotiator": {
@@ -11313,7 +11135,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.4.2",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11321,192 +11143,59 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-      "version": "19.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-      "version": "10.4.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "8.1.0",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.2",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11514,54 +11203,54 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "13.0.1",
+      "version": "13.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.2",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "ignore-walk": "^8.0.0",
-        "proc-log": "^5.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "11.0.1",
+      "version": "11.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-install-checks": "^7.1.0",
-        "npm-normalize-package-bin": "^4.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
         "npm-package-arg": "^13.0.0",
         "semver": "^7.3.5"
       },
@@ -11570,48 +11259,48 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^5.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "19.0.0",
+      "version": "19.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/redact": "^3.0.0",
+        "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
         "make-fetch-happen": "^15.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minizlib": "^3.0.1",
         "npm-package-arg": "^13.0.0",
-        "proc-log": "^5.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.3",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11622,22 +11311,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.3",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
         "@npmcli/run-script": "^10.0.0",
         "cacache": "^20.0.0",
         "fs-minipass": "^3.0.0",
@@ -11646,10 +11330,9 @@
         "npm-packlist": "^10.0.1",
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
+        "proc-log": "^6.0.0",
         "sigstore": "^4.0.0",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "tar": "^7.4.3"
       },
       "bin": {
@@ -11660,30 +11343,21 @@
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
         "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11692,14 +11366,14 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11712,21 +11386,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/proggy": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -11747,29 +11421,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
-      "version": "2.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^4.0.0"
+        "read": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -11781,33 +11442,24 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "4.1.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "^2.0.0"
+        "mute-stream": "^3.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -11818,7 +11470,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11827,27 +11479,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/signal-exit": {
@@ -11863,17 +11494,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11890,12 +11521,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -11917,26 +11548,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "dev": true,
@@ -11954,13 +11565,13 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "12.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11968,61 +11579,7 @@
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
@@ -12038,10 +11595,10 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.1",
+      "version": "7.5.16",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -12049,15 +11606,6 @@
         "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -12075,13 +11623,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12108,7 +11656,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12129,41 +11677,26 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "4.0.0",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -12172,33 +11705,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.2",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
@@ -12211,138 +11724,40 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "5.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "6.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -12358,7 +11773,8 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -12517,7 +11933,8 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -12536,19 +11953,22 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
       "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-bmfont-binary": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
       "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-bmfont-xml": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
       "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xml-parse-from-string": "^1.0.0",
         "xml2js": "^0.5.0"
@@ -12668,19 +12088,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12689,10 +12096,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -12724,6 +12132,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
       "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "pngjs": "^6.0.0"
       },
@@ -12736,6 +12145,7 @@
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
       "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.13.0"
       }
@@ -12844,6 +12254,7 @@
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
       "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
       }
@@ -13079,36 +12490,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/registry-auth-token": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
@@ -13200,31 +12581,15 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -13669,6 +13034,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13874,10 +13240,11 @@
       }
     },
     "node_modules/simple-xml-to-json": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
-      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20.12.2"
       }
@@ -14071,15 +13438,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -14187,16 +13545,16 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -14434,7 +13792,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -14479,10 +13838,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -14509,16 +13869,18 @@
       }
     },
     "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "type": "github",
@@ -14740,10 +14102,24 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -14841,9 +14217,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -14859,6 +14235,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -14885,6 +14262,7 @@
       "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
       "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pako": "^1.0.11"
       }
@@ -15047,13 +14425,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
       "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -15067,6 +14447,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -15094,7 +14475,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -15172,16 +14554,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
@@ -15211,18 +14583,7 @@
       "dev": true,
       "requires": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-          "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-          "dev": true,
-          "requires": {
-            "@fastify/busboy": "^2.0.0"
-          }
-        }
+        "undici": "6.27.0"
       }
     },
     "@actions/io": {
@@ -15232,37 +14593,37 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       }
     },
     "@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -15272,56 +14633,56 @@
       }
     },
     "@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       }
     },
     "@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true
     },
     "@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -15331,40 +14692,40 @@
       "dev": true
     },
     "@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -15521,45 +14882,51 @@
       }
     },
     "@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       }
     },
     "@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       }
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "dev": true
     },
     "@colors/colors": {
@@ -15630,7 +14997,7 @@
         "discord-api-types": "^0.38.40",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "6.27.0"
       },
       "dependencies": {
         "@discordjs/collection": {
@@ -15705,12 +15072,6 @@
       "requires": {
         "tslib": "^2.4.0"
       }
-    },
-    "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true
     },
     "@google/generative-ai": {
       "version": "0.24.1",
@@ -16656,103 +16017,103 @@
       }
     },
     "@jimp/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
       "dev": true,
       "requires": {
-        "@jimp/file-ops": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/file-ops": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "await-to-js": "^3.0.0",
         "exif-parser": "^0.1.12",
-        "file-type": "^16.0.0",
+        "file-type": "^21.3.3",
         "mime": "3"
       }
     },
     "@jimp/diff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
-      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+      "integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
       "dev": true,
       "requires": {
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "pixelmatch": "^5.3.0"
       }
     },
     "@jimp/file-ops": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
-      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+      "integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
       "dev": true
     },
     "@jimp/js-bmp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
-      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+      "integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "bmp-ts": "^1.0.9"
       }
     },
     "@jimp/js-gif": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
-      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+      "integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "gifwrap": "^0.10.1",
         "omggif": "^1.0.10"
       }
     },
     "@jimp/js-jpeg": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
-      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+      "integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "jpeg-js": "^0.4.4"
       }
     },
     "@jimp/js-png": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
-      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+      "integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "pngjs": "^7.0.0"
       }
     },
     "@jimp/js-tiff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
-      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+      "integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "utif2": "^4.1.0"
       }
     },
     "@jimp/plugin-blit": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
-      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+      "integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16765,22 +16126,22 @@
       }
     },
     "@jimp/plugin-blur": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
-      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+      "integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/utils": "1.6.0"
+        "@jimp/core": "1.6.1",
+        "@jimp/utils": "1.6.1"
       }
     },
     "@jimp/plugin-circle": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
-      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+      "integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16793,14 +16154,14 @@
       }
     },
     "@jimp/plugin-color": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
-      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+      "integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "tinycolor2": "^1.6.0",
         "zod": "^3.23.8"
       },
@@ -16814,16 +16175,16 @@
       }
     },
     "@jimp/plugin-contain": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
-      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+      "integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16836,15 +16197,15 @@
       }
     },
     "@jimp/plugin-cover": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
-      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+      "integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16857,14 +16218,14 @@
       }
     },
     "@jimp/plugin-crop": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
-      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+      "integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16877,13 +16238,13 @@
       }
     },
     "@jimp/plugin-displace": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
-      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+      "integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16896,22 +16257,22 @@
       }
     },
     "@jimp/plugin-dither": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
-      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+      "integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0"
+        "@jimp/types": "1.6.1"
       }
     },
     "@jimp/plugin-fisheye": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
-      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+      "integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16924,12 +16285,12 @@
       }
     },
     "@jimp/plugin-flip": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
-      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+      "integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16942,30 +16303,30 @@
       }
     },
     "@jimp/plugin-hash": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
-      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+      "integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "any-base": "^1.1.0"
       }
     },
     "@jimp/plugin-mask": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
-      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+      "integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -16978,16 +16339,16 @@
       }
     },
     "@jimp/plugin-print": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
-      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+      "integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/types": "1.6.1",
         "parse-bmfont-ascii": "^1.0.6",
         "parse-bmfont-binary": "^1.0.6",
         "parse-bmfont-xml": "^1.1.6",
@@ -17004,9 +16365,9 @@
       }
     },
     "@jimp/plugin-quantize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
-      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+      "integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
       "dev": true,
       "requires": {
         "image-q": "^4.0.0",
@@ -17022,13 +16383,13 @@
       }
     },
     "@jimp/plugin-resize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
-      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+      "integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -17041,16 +16402,16 @@
       }
     },
     "@jimp/plugin-rotate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
-      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+      "integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -17063,16 +16424,16 @@
       }
     },
     "@jimp/plugin-threshold": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
-      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+      "integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
         "zod": "^3.23.8"
       },
       "dependencies": {
@@ -17085,9 +16446,9 @@
       }
     },
     "@jimp/types": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
-      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+      "integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
       "dev": true,
       "requires": {
         "zod": "^3.23.8"
@@ -17102,12 +16463,12 @@
       }
     },
     "@jimp/utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
       "dev": true,
       "requires": {
-        "@jimp/types": "1.6.0",
+        "@jimp/types": "1.6.1",
         "tinycolor2": "^1.6.0"
       }
     },
@@ -17447,7 +16808,7 @@
         "mime": "^4.0.0",
         "p-filter": "^4.0.0",
         "tinyglobby": "^0.2.14",
-        "undici": "^7.0.0",
+        "undici": "6.27.0",
         "url-join": "^5.0.0"
       },
       "dependencies": {
@@ -17458,9 +16819,8 @@
           "dev": true
         },
         "undici": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-          "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+          "version": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+          "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
           "dev": true
         }
       }
@@ -17658,6 +17018,16 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
       }
     },
     "@tokenizer/token": {
@@ -18206,9 +17576,9 @@
       "dev": true
     },
     "baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true
     },
     "before-after-hook": {
@@ -18229,9 +17599,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -18248,16 +17618,16 @@
       }
     },
     "browserslist": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "requires": {
-        "baseline-browser-mapping": "^2.8.19",
-        "caniuse-lite": "^1.0.30001751",
-        "electron-to-chromium": "^1.5.238",
-        "node-releases": "^2.0.26",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       }
     },
     "bs-logger": {
@@ -18306,9 +17676,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001751",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
-      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true
     },
     "chalk": {
@@ -18601,9 +17971,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-          "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+          "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
@@ -18646,9 +18016,9 @@
       }
     },
     "debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
         "ms": "^2.1.3"
       }
@@ -18689,9 +18059,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true
     },
     "dir-glob": {
@@ -18725,7 +18095,7 @@
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "6.27.0"
       }
     },
     "dot-prop": {
@@ -18800,9 +18170,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.242.tgz",
-      "integrity": "sha512-msZ7SYGFpXkm/iUizlMrm/FPNeYo8uSltQccLVFO3fV4RN2JWGdG7Aatztxtw3uDWp3DkupfkrosLjUnhY+iOw==",
+      "version": "1.5.381",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
       "dev": true
     },
     "emittery": {
@@ -19064,14 +18434,15 @@
       }
     },
     "file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "dev": true,
       "requires": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       }
     },
     "fill-range": {
@@ -19133,15 +18504,15 @@
       }
     },
     "form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       }
     },
     "fs-extra": {
@@ -20553,9 +19924,9 @@
           }
         },
         "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -20996,9 +20367,9 @@
           }
         },
         "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         },
         "pretty-format": {
@@ -21394,9 +20765,9 @@
           "dev": true
         },
         "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         }
       }
@@ -21546,38 +20917,38 @@
       }
     },
     "jimp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
-      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+      "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "dev": true,
       "requires": {
-        "@jimp/core": "1.6.0",
-        "@jimp/diff": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-gif": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-blur": "1.6.0",
-        "@jimp/plugin-circle": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-contain": "1.6.0",
-        "@jimp/plugin-cover": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-displace": "1.6.0",
-        "@jimp/plugin-dither": "1.6.0",
-        "@jimp/plugin-fisheye": "1.6.0",
-        "@jimp/plugin-flip": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/plugin-mask": "1.6.0",
-        "@jimp/plugin-print": "1.6.0",
-        "@jimp/plugin-quantize": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/plugin-rotate": "1.6.0",
-        "@jimp/plugin-threshold": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0"
+        "@jimp/core": "1.6.1",
+        "@jimp/diff": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-gif": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-blur": "1.6.1",
+        "@jimp/plugin-circle": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-contain": "1.6.1",
+        "@jimp/plugin-cover": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-displace": "1.6.1",
+        "@jimp/plugin-dither": "1.6.1",
+        "@jimp/plugin-fisheye": "1.6.1",
+        "@jimp/plugin-flip": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/plugin-mask": "1.6.1",
+        "@jimp/plugin-print": "1.6.1",
+        "@jimp/plugin-quantize": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/plugin-rotate": "1.6.1",
+        "@jimp/plugin-threshold": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1"
       }
     },
     "jpeg-js": {
@@ -21593,9 +20964,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -22137,9 +21508,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
-      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true
     },
     "normalize-package-data": {
@@ -22174,133 +21545,82 @@
       "dev": true
     },
     "npm": {
-      "version": "11.6.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.6.2.tgz",
-      "integrity": "sha512-7iKzNfy8lWYs3zq4oFPa8EXZz5xt9gQNKJZau3B1ErLBb6bF7sBJ00x09485DOvRT2l5Gerbl3VlZNT57MxJVA==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.6",
-        "@npmcli/config": "^10.4.2",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/package-json": "^7.0.1",
-        "@npmcli/promise-spawn": "^8.0.3",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^10.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "abbrev": "^3.0.1",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.1",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
-        "cli-columns": "^4.0.0",
+        "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^11.0.3",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
-        "ini": "^5.0.0",
-        "init-package-json": "^8.2.2",
-        "is-cidr": "^6.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
+        "hosted-git-info": "^9.0.3",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.9",
-        "libnpmexec": "^10.1.8",
-        "libnpmfund": "^7.0.9",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.9",
-        "libnpmpublish": "^11.1.2",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.2",
-        "make-fetch-happen": "^15.0.2",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.1",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.4.2",
-        "nopt": "^8.1.0",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.2",
-        "npm-package-arg": "^13.0.1",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-profile": "^12.0.0",
-        "npm-registry-fetch": "^19.0.0",
-        "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
-        "pacote": "^21.0.3",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "node-gyp": "^12.4.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.1",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^21.5.1",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
-        "semver": "^7.7.3",
+        "read": "^5.0.1",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.1",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.2",
-        "which": "^5.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "dependencies": {
-        "@isaacs/balanced-match": {
-          "version": "4.0.1",
+        "@gar/promise-retry": {
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
-        },
-        "@isaacs/brace-expansion": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@isaacs/balanced-match": "^4.0.1"
-          }
-        },
-        "@isaacs/cliui": {
-          "version": "8.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^5.1.2",
-            "string-width-cjs": "npm:string-width@^4.2.0",
-            "strip-ansi": "^7.0.1",
-            "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-            "wrap-ansi": "^8.1.0",
-            "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^6.0.1"
-              }
-            }
-          }
         },
         "@isaacs/fs-minipass": {
           "version": "4.0.1",
@@ -22316,7 +21636,7 @@
           "dev": true
         },
         "@npmcli/agent": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22328,62 +21648,63 @@
           }
         },
         "@npmcli/arborist": {
-          "version": "9.1.6",
+          "version": "9.8.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.0",
             "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/fs": "^4.0.0",
-            "@npmcli/installed-package-contents": "^3.0.0",
+            "@npmcli/fs": "^5.0.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
             "@npmcli/map-workspaces": "^5.0.0",
             "@npmcli/metavuln-calculator": "^9.0.2",
-            "@npmcli/name-from-folder": "^3.0.0",
-            "@npmcli/node-gyp": "^4.0.0",
+            "@npmcli/name-from-folder": "^4.0.0",
+            "@npmcli/node-gyp": "^5.0.0",
             "@npmcli/package-json": "^7.0.0",
-            "@npmcli/query": "^4.0.0",
-            "@npmcli/redact": "^3.0.0",
+            "@npmcli/query": "^5.0.0",
+            "@npmcli/redact": "^4.0.0",
             "@npmcli/run-script": "^10.0.0",
-            "bin-links": "^5.0.0",
+            "bin-links": "^6.0.0",
             "cacache": "^20.0.1",
-            "common-ancestor-path": "^1.0.1",
+            "common-ancestor-path": "^2.0.0",
             "hosted-git-info": "^9.0.0",
             "json-stringify-nice": "^1.1.4",
             "lru-cache": "^11.2.1",
             "minimatch": "^10.0.3",
-            "nopt": "^8.0.0",
-            "npm-install-checks": "^7.1.0",
+            "nopt": "^9.0.0",
+            "npm-install-checks": "^8.0.0",
             "npm-package-arg": "^13.0.0",
             "npm-pick-manifest": "^11.0.1",
             "npm-registry-fetch": "^19.0.0",
             "pacote": "^21.0.2",
-            "parse-conflict-json": "^4.0.0",
-            "proc-log": "^5.0.0",
-            "proggy": "^3.0.0",
+            "parse-conflict-json": "^5.0.1",
+            "proc-log": "^6.0.0",
+            "proggy": "^4.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^3.0.1",
             "semver": "^7.3.7",
-            "ssri": "^12.0.0",
+            "ssri": "^13.0.0",
             "treeverse": "^3.0.0",
             "walk-up-path": "^4.0.0"
           }
         },
         "@npmcli/config": {
-          "version": "10.4.2",
+          "version": "10.11.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^5.0.0",
             "@npmcli/package-json": "^7.0.0",
             "ci-info": "^4.0.0",
-            "ini": "^5.0.0",
-            "nopt": "^8.1.0",
-            "proc-log": "^5.0.0",
+            "ini": "^6.0.0",
+            "nopt": "^9.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
             "walk-up-path": "^4.0.0"
           }
         },
         "@npmcli/fs": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22391,86 +21712,86 @@
           }
         },
         "@npmcli/git": {
-          "version": "7.0.0",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/promise-spawn": "^8.0.0",
-            "ini": "^5.0.0",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/promise-spawn": "^9.0.0",
+            "ini": "^6.0.0",
             "lru-cache": "^11.2.1",
             "npm-pick-manifest": "^11.0.1",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "which": "^5.0.0"
+            "which": "^6.0.0"
           }
         },
         "@npmcli/installed-package-contents": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-bundled": "^4.0.0",
-            "npm-normalize-package-bin": "^4.0.0"
+            "npm-bundled": "^5.0.0",
+            "npm-normalize-package-bin": "^5.0.0"
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "5.0.0",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/name-from-folder": "^3.0.0",
+            "@npmcli/name-from-folder": "^4.0.0",
             "@npmcli/package-json": "^7.0.0",
-            "glob": "^11.0.3",
+            "glob": "^13.0.0",
             "minimatch": "^10.0.3"
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "9.0.2",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "cacache": "^20.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
             "pacote": "^21.0.0",
-            "proc-log": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5"
           }
         },
         "@npmcli/name-from-folder": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "@npmcli/node-gyp": {
           "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
+        "@npmcli/node-gyp": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/package-json": {
-          "version": "7.0.1",
+          "version": "7.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^7.0.0",
-            "glob": "^11.0.3",
+            "glob": "^13.0.0",
             "hosted-git-info": "^9.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
-            "proc-log": "^5.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.5.3",
-            "validate-npm-package-license": "^3.0.4"
+            "spdx-expression-parse": "^4.0.0"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "8.0.3",
+          "version": "9.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "which": "^5.0.0"
+            "which": "^6.0.0"
           }
         },
         "@npmcli/query": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22478,28 +21799,21 @@
           }
         },
         "@npmcli/redact": {
-          "version": "3.2.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/run-script": {
-          "version": "10.0.0",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^4.0.0",
+            "@npmcli/node-gyp": "^5.0.0",
             "@npmcli/package-json": "^7.0.0",
-            "@npmcli/promise-spawn": "^8.0.0",
-            "node-gyp": "^11.0.0",
-            "proc-log": "^5.0.0",
-            "which": "^5.0.0"
+            "@npmcli/promise-spawn": "^9.0.0",
+            "node-gyp": "^12.1.0",
+            "proc-log": "^6.0.0"
           }
-        },
-        "@pkgjs/parseargs": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "@sigstore/bundle": {
           "version": "4.0.0",
@@ -22510,44 +21824,44 @@
           }
         },
         "@sigstore/core": {
-          "version": "3.0.0",
+          "version": "3.2.1",
           "bundled": true,
           "dev": true
         },
         "@sigstore/protobuf-specs": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true
         },
         "@sigstore/sign": {
-          "version": "4.0.1",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.2",
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.0.0",
+            "@sigstore/core": "^3.2.0",
             "@sigstore/protobuf-specs": "^0.5.0",
-            "make-fetch-happen": "^15.0.2",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1"
+            "make-fetch-happen": "^15.0.4",
+            "proc-log": "^6.1.0"
           }
         },
         "@sigstore/tuf": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@sigstore/protobuf-specs": "^0.5.0",
-            "tuf-js": "^4.0.0"
+            "tuf-js": "^4.1.0"
           }
         },
         "@sigstore/verify": {
-          "version": "3.0.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.0.0",
+            "@sigstore/core": "^3.2.1",
             "@sigstore/protobuf-specs": "^0.5.0"
           }
         },
@@ -22557,41 +21871,21 @@
           "dev": true
         },
         "@tufjs/models": {
-          "version": "4.0.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@tufjs/canonical-json": "2.0.0",
-            "minimatch": "^9.0.5"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "9.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            }
+            "minimatch": "^10.1.1"
           }
         },
         "abbrev": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "agent-base": {
           "version": "7.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "6.2.3",
           "bundled": true,
           "dev": true
         },
@@ -22606,20 +21900,20 @@
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.2",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true
         },
         "bin-links": {
-          "version": "5.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cmd-shim": "^7.0.0",
-            "npm-normalize-package-bin": "^4.0.0",
-            "proc-log": "^5.0.0",
-            "read-cmd-shim": "^5.0.0",
-            "write-file-atomic": "^6.0.0"
+            "cmd-shim": "^8.0.0",
+            "npm-normalize-package-bin": "^5.0.0",
+            "proc-log": "^6.0.0",
+            "read-cmd-shim": "^6.0.0",
+            "write-file-atomic": "^7.0.0"
           }
         },
         "binary-extensions": {
@@ -22628,29 +21922,28 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.0.2",
+          "version": "5.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0"
+            "balanced-match": "^4.0.2"
           }
         },
         "cacache": {
-          "version": "20.0.1",
+          "version": "20.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^4.0.0",
+            "@npmcli/fs": "^5.0.0",
             "fs-minipass": "^3.0.0",
-            "glob": "^11.0.3",
+            "glob": "^13.0.0",
             "lru-cache": "^11.1.0",
             "minipass": "^7.0.3",
             "minipass-collect": "^2.0.1",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "p-map": "^7.0.2",
-            "ssri": "^12.0.0",
-            "unique-filename": "^4.0.0"
+            "ssri": "^13.0.0"
           }
         },
         "chalk": {
@@ -22664,74 +21957,24 @@
           "dev": true
         },
         "ci-info": {
-          "version": "4.3.1",
+          "version": "4.4.0",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ip-regex": "5.0.0"
-          }
-        },
-        "cli-columns": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "cmd-shim": {
-          "version": "7.0.0",
+          "version": "5.0.5",
           "bundled": true,
           "dev": true
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
+        "cmd-shim": {
+          "version": "8.0.0",
           "bundled": true,
           "dev": true
         },
         "common-ancestor-path": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "which": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
         },
         "cssesc": {
           "version": "3.0.0",
@@ -22747,41 +21990,17 @@
           }
         },
         "diff": {
-          "version": "8.0.2",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true
-        },
-        "eastasianwidth": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.13",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "iconv-lite": "^0.6.2"
-          }
         },
         "env-paths": {
           "version": "2.2.1",
           "bundled": true,
           "dev": true
         },
-        "err-code": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
         "exponential-backoff": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "bundled": true,
           "dev": true
         },
@@ -22789,15 +22008,6 @@
           "version": "1.0.16",
           "bundled": true,
           "dev": true
-        },
-        "foreground-child": {
-          "version": "3.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.6",
-            "signal-exit": "^4.0.1"
-          }
         },
         "fs-minipass": {
           "version": "3.0.3",
@@ -22808,16 +22018,13 @@
           }
         },
         "glob": {
-          "version": "11.0.3",
+          "version": "13.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "^3.3.1",
-            "jackspeak": "^4.1.1",
-            "minimatch": "^10.0.3",
-            "minipass": "^7.1.2",
-            "package-json-from-dist": "^1.0.0",
-            "path-scurry": "^2.0.0"
+            "minimatch": "^10.2.2",
+            "minipass": "^7.1.3",
+            "path-scurry": "^2.0.2"
           }
         },
         "graceful-fs": {
@@ -22826,7 +22033,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "9.0.2",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22857,7 +22064,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.6.3",
+          "version": "0.7.2",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -22873,68 +22080,44 @@
             "minimatch": "^10.0.3"
           }
         },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
         "ini": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "8.2.2",
+          "version": "8.2.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/package-json": "^7.0.0",
             "npm-package-arg": "^13.0.0",
-            "promzard": "^2.0.0",
-            "read": "^4.0.0",
+            "promzard": "^3.0.1",
+            "read": "^5.0.1",
             "semver": "^7.7.2",
-            "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^6.0.2"
+            "validate-npm-package-name": "^7.0.0"
           }
         },
         "ip-address": {
-          "version": "10.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ip-regex": {
-          "version": "5.0.0",
+          "version": "10.2.0",
           "bundled": true,
           "dev": true
         },
         "is-cidr": {
-          "version": "6.0.1",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "5.0.1"
+            "cidr-regex": "^5.0.4"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
         },
         "isexe": {
-          "version": "3.1.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
-        "jackspeak": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@isaacs/cliui": "^8.0.2"
-          }
-        },
         "json-parse-even-better-errors": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         },
@@ -22968,12 +22151,12 @@
           }
         },
         "libnpmdiff": {
-          "version": "8.0.9",
+          "version": "8.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.1.6",
-            "@npmcli/installed-package-contents": "^3.0.0",
+            "@npmcli/arborist": "^9.8.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
             "binary-extensions": "^3.0.0",
             "diff": "^8.0.2",
             "minimatch": "^10.0.3",
@@ -22983,30 +22166,30 @@
           }
         },
         "libnpmexec": {
-          "version": "10.1.8",
+          "version": "10.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.1.6",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/arborist": "^9.8.0",
             "@npmcli/package-json": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
             "ci-info": "^4.0.0",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
-            "read": "^4.0.0",
+            "proc-log": "^6.0.0",
+            "read": "^5.0.1",
             "semver": "^7.3.7",
             "signal-exit": "^4.1.0",
             "walk-up-path": "^4.0.0"
           }
         },
         "libnpmfund": {
-          "version": "7.0.9",
+          "version": "7.0.24",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.1.6"
+            "@npmcli/arborist": "^9.8.0"
           }
         },
         "libnpmorg": {
@@ -23019,18 +22202,18 @@
           }
         },
         "libnpmpack": {
-          "version": "9.0.9",
+          "version": "9.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.1.6",
+            "@npmcli/arborist": "^9.8.0",
             "@npmcli/run-script": "^10.0.0",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2"
           }
         },
         "libnpmpublish": {
-          "version": "11.1.2",
+          "version": "11.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23038,10 +22221,10 @@
             "ci-info": "^4.0.0",
             "npm-package-arg": "^13.0.0",
             "npm-registry-fetch": "^19.0.0",
-            "proc-log": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.7",
             "sigstore": "^4.0.0",
-            "ssri": "^12.0.0"
+            "ssri": "^13.0.0"
           }
         },
         "libnpmsearch": {
@@ -23062,50 +22245,51 @@
           }
         },
         "libnpmversion": {
-          "version": "8.0.2",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
-            "proc-log": "^5.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "11.2.2",
+          "version": "11.5.1",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "15.0.2",
+          "version": "15.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.0",
             "@npmcli/agent": "^4.0.0",
+            "@npmcli/redact": "^4.0.0",
             "cacache": "^20.0.1",
             "http-cache-semantics": "^4.1.1",
             "minipass": "^7.0.2",
-            "minipass-fetch": "^4.0.0",
+            "minipass-fetch": "^5.0.0",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^1.0.0",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
-            "ssri": "^12.0.0"
+            "proc-log": "^6.0.0",
+            "ssri": "^13.0.0"
           }
         },
         "minimatch": {
-          "version": "10.0.3",
+          "version": "10.2.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@isaacs/brace-expansion": "^5.0.0"
+            "brace-expansion": "^5.0.5"
           }
         },
         "minipass": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true
         },
@@ -23118,32 +22302,22 @@
           }
         },
         "minipass-fetch": {
-          "version": "4.0.1",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "^0.1.13",
+            "iconv-lite": "^0.7.2",
             "minipass": "^7.0.3",
-            "minipass-sized": "^1.0.3",
+            "minipass-sized": "^2.0.0",
             "minizlib": "^3.0.1"
           }
         },
         "minipass-flush": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
+            "minipass": "^7.1.3"
           }
         },
         "minipass-pipeline": {
@@ -23161,25 +22335,20 @@
               "requires": {
                 "yallist": "^4.0.0"
               }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "minipass-sized": {
-          "version": "1.0.3",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
+            "minipass": "^7.1.2"
           }
         },
         "minizlib": {
@@ -23196,7 +22365,7 @@
           "dev": true
         },
         "mute-stream": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -23206,140 +22375,45 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "11.4.2",
+          "version": "12.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^14.0.3",
-            "nopt": "^8.0.0",
-            "proc-log": "^5.0.0",
+            "nopt": "^9.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "tar": "^7.4.3",
+            "tar": "^7.5.4",
             "tinyglobby": "^0.2.12",
-            "which": "^5.0.0"
-          },
-          "dependencies": {
-            "@npmcli/agent": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^10.0.1",
-                "socks-proxy-agent": "^8.0.3"
-              }
-            },
-            "cacache": {
-              "version": "19.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@npmcli/fs": "^4.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^10.0.1",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^12.0.0",
-                "tar": "^7.4.3",
-                "unique-filename": "^4.0.0"
-              }
-            },
-            "glob": {
-              "version": "10.4.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-              }
-            },
-            "jackspeak": {
-              "version": "3.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@isaacs/cliui": "^8.0.2",
-                "@pkgjs/parseargs": "^0.11.0"
-              }
-            },
-            "lru-cache": {
-              "version": "10.4.3",
-              "bundled": true,
-              "dev": true
-            },
-            "make-fetch-happen": {
-              "version": "14.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@npmcli/agent": "^3.0.0",
-                "cacache": "^19.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^4.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^5.0.0",
-                "promise-retry": "^2.0.1",
-                "ssri": "^12.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "9.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "path-scurry": {
-              "version": "1.11.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-              }
-            }
+            "undici": "6.27.0",
+            "which": "^6.0.0"
           }
         },
         "nopt": {
-          "version": "8.1.0",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "^3.0.0"
+            "abbrev": "^4.0.0"
           }
         },
         "npm-audit-report": {
-          "version": "6.0.0",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true
         },
         "npm-bundled": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-normalize-package-bin": "^4.0.0"
+            "npm-normalize-package-bin": "^5.0.0"
           }
         },
         "npm-install-checks": {
-          "version": "7.1.2",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23347,89 +22421,85 @@
           }
         },
         "npm-normalize-package-bin": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
-          "version": "13.0.1",
+          "version": "13.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^9.0.0",
-            "proc-log": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^6.0.0"
+            "validate-npm-package-name": "^7.0.0"
           }
         },
         "npm-packlist": {
-          "version": "10.0.2",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "ignore-walk": "^8.0.0",
-            "proc-log": "^5.0.0"
+            "proc-log": "^6.0.0"
           }
         },
         "npm-pick-manifest": {
-          "version": "11.0.1",
+          "version": "11.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-install-checks": "^7.1.0",
-            "npm-normalize-package-bin": "^4.0.0",
+            "npm-install-checks": "^8.0.0",
+            "npm-normalize-package-bin": "^5.0.0",
             "npm-package-arg": "^13.0.0",
             "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "12.0.0",
+          "version": "12.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-registry-fetch": "^19.0.0",
-            "proc-log": "^5.0.0"
+            "proc-log": "^6.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "19.0.0",
+          "version": "19.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/redact": "^3.0.0",
+            "@npmcli/redact": "^4.0.0",
             "jsonparse": "^1.3.1",
             "make-fetch-happen": "^15.0.0",
             "minipass": "^7.0.2",
-            "minipass-fetch": "^4.0.0",
+            "minipass-fetch": "^5.0.0",
             "minizlib": "^3.0.1",
             "npm-package-arg": "^13.0.0",
-            "proc-log": "^5.0.0"
+            "proc-log": "^6.0.0"
           }
         },
         "npm-user-validate": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "p-map": {
-          "version": "7.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json-from-dist": {
-          "version": "1.0.1",
+          "version": "7.0.4",
           "bundled": true,
           "dev": true
         },
         "pacote": {
-          "version": "21.0.3",
+          "version": "21.5.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.0",
             "@npmcli/git": "^7.0.0",
-            "@npmcli/installed-package-contents": "^3.0.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
             "@npmcli/package-json": "^7.0.0",
-            "@npmcli/promise-spawn": "^8.0.0",
+            "@npmcli/promise-spawn": "^9.0.0",
             "@npmcli/run-script": "^10.0.0",
             "cacache": "^20.0.0",
             "fs-minipass": "^3.0.0",
@@ -23438,30 +22508,24 @@
             "npm-packlist": "^10.0.1",
             "npm-pick-manifest": "^11.0.1",
             "npm-registry-fetch": "^19.0.0",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
+            "proc-log": "^6.0.0",
             "sigstore": "^4.0.0",
-            "ssri": "^12.0.0",
+            "ssri": "^13.0.0",
             "tar": "^7.4.3"
           }
         },
         "parse-conflict-json": {
-          "version": "4.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^4.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
             "just-diff": "^6.0.0",
             "just-diff-apply": "^5.2.0"
           }
         },
-        "path-key": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "path-scurry": {
-          "version": "2.0.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23470,7 +22534,7 @@
           }
         },
         "postcss-selector-parser": {
-          "version": "7.1.0",
+          "version": "7.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23479,12 +22543,12 @@
           }
         },
         "proc-log": {
-          "version": "5.0.0",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true
         },
         "proggy": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -23498,21 +22562,12 @@
           "bundled": true,
           "dev": true
         },
-        "promise-retry": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "err-code": "^2.0.2",
-            "retry": "^0.12.0"
-          }
-        },
         "promzard": {
-          "version": "2.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "^4.0.0"
+            "read": "^5.0.0"
           }
         },
         "qrcode-terminal": {
@@ -23521,20 +22576,15 @@
           "dev": true
         },
         "read": {
-          "version": "4.1.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "^2.0.0"
+            "mute-stream": "^3.0.0"
           }
         },
         "read-cmd-shim": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "retry": {
-          "version": "0.12.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true
         },
@@ -23545,20 +22595,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.7.3",
-          "bundled": true,
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
+          "version": "7.8.4",
           "bundled": true,
           "dev": true
         },
@@ -23568,16 +22605,16 @@
           "dev": true
         },
         "sigstore": {
-          "version": "4.0.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.0.0",
+            "@sigstore/core": "^3.2.1",
             "@sigstore/protobuf-specs": "^0.5.0",
-            "@sigstore/sign": "^4.0.0",
-            "@sigstore/tuf": "^4.0.0",
-            "@sigstore/verify": "^3.0.0"
+            "@sigstore/sign": "^4.1.1",
+            "@sigstore/tuf": "^4.0.2",
+            "@sigstore/verify": "^3.1.1"
           }
         },
         "smart-buffer": {
@@ -23586,11 +22623,11 @@
           "dev": true
         },
         "socks": {
-          "version": "2.8.7",
+          "version": "2.8.9",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-address": "^10.0.1",
+            "ip-address": "^10.1.1",
             "smart-buffer": "^4.2.0"
           }
         },
@@ -23602,26 +22639,6 @@
             "agent-base": "^7.1.2",
             "debug": "^4.3.4",
             "socks": "^2.8.3"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-expression-parse": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            }
           }
         },
         "spdx-exceptions": {
@@ -23639,52 +22656,16 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.22",
+          "version": "3.0.23",
           "bundled": true,
           "dev": true
         },
         "ssri": {
-          "version": "12.0.0",
+          "version": "13.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "minipass": "^7.0.3"
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "string-width-cjs": {
-          "version": "npm:string-width@4.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strip-ansi-cjs": {
-          "version": "npm:strip-ansi@6.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -23693,7 +22674,7 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.1",
+          "version": "7.5.16",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23702,13 +22683,6 @@
             "minipass": "^7.1.2",
             "minizlib": "^3.1.0",
             "yallist": "^5.0.0"
-          },
-          "dependencies": {
-            "yallist": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "text-table": {
@@ -23722,12 +22696,12 @@
           "dev": true
         },
         "tinyglobby": {
-          "version": "0.2.15",
+          "version": "0.2.17",
           "bundled": true,
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": "^4.0.3"
+            "picomatch": "^4.0.4"
           },
           "dependencies": {
             "fdir": {
@@ -23737,7 +22711,7 @@
               "requires": {}
             },
             "picomatch": {
-              "version": "4.0.3",
+              "version": "4.0.4",
               "bundled": true,
               "dev": true
             }
@@ -23749,58 +22723,27 @@
           "dev": true
         },
         "tuf-js": {
-          "version": "4.0.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tufjs/models": "4.0.0",
-            "debug": "^4.4.1",
-            "make-fetch-happen": "^15.0.0"
+            "@tufjs/models": "4.1.0",
+            "debug": "^4.4.3",
+            "make-fetch-happen": "^15.0.1"
           }
         },
-        "unique-filename": {
-          "version": "4.0.0",
+        "undici": {
+          "version": "6.26.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "unique-slug": "^5.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-expression-parse": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            }
-          }
-        },
         "validate-npm-package-name": {
-          "version": "6.0.2",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true
         },
@@ -23810,84 +22753,23 @@
           "dev": true
         },
         "which": {
-          "version": "5.0.0",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "^3.1.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "8.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^6.0.1"
-              }
-            }
-          }
-        },
-        "wrap-ansi-cjs": {
-          "version": "npm:wrap-ansi@7.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            }
+            "isexe": "^4.0.0"
           }
         },
         "write-file-atomic": {
-          "version": "6.0.0",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "imurmurhash": "^0.1.4",
             "signal-exit": "^4.0.1"
           }
         },
         "yallist": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         }
@@ -24126,12 +23008,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -24139,9 +23015,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pify": {
@@ -24405,26 +23281,6 @@
         }
       }
     },
-    "readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^3.6.0"
-      }
-    },
     "registry-auth-token": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
@@ -24488,16 +23344,10 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
-    },
     "sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true
     },
     "semantic-release": {
@@ -24943,9 +23793,9 @@
       }
     },
     "simple-xml-to-json": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
-      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
       "dev": true
     },
     "skin-tone": {
@@ -25101,15 +23951,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -25185,13 +24026,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
       "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
+        "@tokenizer/token": "^0.3.0"
       }
     },
     "super-regex": {
@@ -25386,9 +24226,9 @@
           "requires": {}
         },
         "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         }
       }
@@ -25409,11 +24249,12 @@
       }
     },
     "token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "dev": true,
       "requires": {
+        "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       }
@@ -25524,10 +24365,16 @@
       "dev": true,
       "optional": true
     },
+    "uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true
+    },
     "undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="
     },
     "undici-types": {
       "version": "7.24.6",
@@ -25595,9 +24442,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "requires": {
         "escalade": "^3.2.0",
@@ -25813,13 +24660,6 @@
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true
-    },
-    "zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "optional": true,
-      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "undici": "6.27.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,13 @@ export const WILDCARD = parseInt(process.env.WILDCARD ?? '0', 10);
 export const DEBUG = process.env.DEBUG === 'true' || false; // Default DEBUG to false
 export const GEMINI_API_KEY = process.env.GEMINI_API_KEY; // Optional: for Gemini image generation
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY; // For DALL-E image generation (cost monitoring not available via API)
+/** OpenAI Images API model id. Prod keys often expose gpt-image-1, not dall-e-3. */
+export const OPENAI_IMAGE_MODEL = process.env.OPENAI_IMAGE_MODEL || 'gpt-image-1';
+/** Retries when Gemini returns an empty image payload (intermittent SDK flake). */
+export const GEMINI_IMAGE_MAX_ATTEMPTS = Math.max(
+    1,
+    parseInt(process.env.GEMINI_IMAGE_MAX_ATTEMPTS || '3', 10)
+);
 export const GOOGLE_CLOUD_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT_ID; // Optional: for Gemini cost monitoring
 
 // Get version from version.txt - no fallback, must exist

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,6 +1,6 @@
-import { GoogleGenerativeAI, GenerativeModel } from '@google/generative-ai';
+import { GoogleGenerativeAI, GenerativeModel, GenerateContentResult } from '@google/generative-ai';
 import axios from 'axios';
-import { GEMINI_API_KEY, DEBUG } from '../config';
+import { GEMINI_API_KEY, DEBUG, GEMINI_IMAGE_MAX_ATTEMPTS } from '../config';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -142,6 +142,63 @@ function getMimeType(imagePath: string): string {
 // For now, let's use inline data approach with proper structure
 // TODO: Implement proper File API upload when needed
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function summarizeGeminiParts(parts: Array<{ inlineData?: { data?: string }; text?: string }>): string {
+  return parts
+    .map((part) => {
+      if (part.inlineData?.data) {
+        return 'IMAGE';
+      }
+      if (part.text !== undefined) {
+        return `TEXT(${part.text.length}ch)`;
+      }
+      return 'UNKNOWN';
+    })
+    .join(',');
+}
+
+/** Returns a temp file path when inline image data is present; null when the model returned no image. */
+function extractImageFromGeminiResponse(result: GenerateContentResult): string | null {
+  if (!result.response.candidates || result.response.candidates.length === 0) {
+    return null;
+  }
+
+  const candidate = result.response.candidates[0];
+  if (!candidate.content?.parts) {
+    return null;
+  }
+
+  for (const part of candidate.content.parts) {
+    if (part.inlineData?.data) {
+      const imageData = part.inlineData.data;
+      const tempDir = path.join(__dirname, '../../temp');
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+
+      const tempFilePath = path.join(tempDir, `gemini-generated-${Date.now()}.png`);
+      const imageBuffer = Buffer.from(imageData, 'base64');
+      fs.writeFileSync(tempFilePath, imageBuffer);
+
+      if (DEBUG) {
+        console.log(`DEBUG: Saved Gemini generated image to: ${tempFilePath}`);
+        console.log(`DEBUG: File size: ${imageBuffer.length} bytes`);
+      }
+
+      return tempFilePath;
+    }
+
+    if (part.text && DEBUG) {
+      console.log('DEBUG: Text part in response:', part.text.substring(0, 200) + '...');
+    }
+  }
+
+  return null;
+}
+
 // Generate image using Gemini with the CORRECT image generation API
 export async function generateImageWithGemini(options: GeminiImageOptions): Promise<string> {
   return await generateImageWithGeminiInternal(options);
@@ -204,10 +261,6 @@ async function generateImageWithGeminiInternal(options: GeminiImageOptions): Pro
     const client = getGeminiClient();
     const modelInstance = client.getGenerativeModel({ model: model });
 
-    if (DEBUG) {
-      console.log('DEBUG: Calling model.generateContent() with SDK...');
-    }
-
     // Prepare content for generation
     let content: any;
     if (imageInput && fs.existsSync(imageInput)) {
@@ -231,60 +284,35 @@ async function generateImageWithGeminiInternal(options: GeminiImageOptions): Pro
       content = finalPrompt;
     }
 
-    const result = await modelInstance.generateContent(content);
+    for (let attempt = 1; attempt <= GEMINI_IMAGE_MAX_ATTEMPTS; attempt++) {
+      if (DEBUG) {
+        console.log(`DEBUG: Calling model.generateContent() with SDK (attempt ${attempt}/${GEMINI_IMAGE_MAX_ATTEMPTS})...`);
+      }
 
-    if (DEBUG) {
-      console.log('DEBUG: Gemini SDK response received');
-      console.log('DEBUG: Candidates:', result.response.candidates?.length || 0);
-    }
+      const result = await modelInstance.generateContent(content);
 
-    // Extract image data from SDK response (different structure than REST API)
-    if (result.response.candidates && result.response.candidates.length > 0) {
-      const candidate = result.response.candidates[0];
+      if (DEBUG) {
+        console.log('DEBUG: Gemini SDK response received');
+        console.log('DEBUG: Candidates:', result.response.candidates?.length || 0);
+      }
 
-      if (candidate.content && candidate.content.parts) {
-        for (const part of candidate.content.parts) {
-          // Check for inline data (image response)
-          if (part.inlineData && part.inlineData.data) {
-            const imageData = part.inlineData.data;
-            const mimeType = part.inlineData.mimeType || 'image/png';
-
-            if (DEBUG) {
-              console.log(`DEBUG: Found inline image data, mimeType: ${mimeType}`);
-              console.log(`DEBUG: Data length: ${imageData.length}`);
-            }
-
-            // Convert base64 to temporary file
-            const tempDir = path.join(__dirname, '../../temp');
-            if (!fs.existsSync(tempDir)) {
-              fs.mkdirSync(tempDir, { recursive: true });
-            }
-
-            const tempFileName = `gemini-generated-${Date.now()}.png`;
-            const tempFilePath = path.join(tempDir, tempFileName);
-
-            try {
-              // Decode base64 and save as file
-              const imageBuffer = Buffer.from(imageData, 'base64');
-              fs.writeFileSync(tempFilePath, imageBuffer);
-
-              if (DEBUG) {
-                console.log(`DEBUG: Saved Gemini generated image to: ${tempFilePath}`);
-                console.log(`DEBUG: File size: ${imageBuffer.length} bytes`);
-              }
-
-              return tempFilePath;
-            } catch (bufferError) {
-              console.error('DEBUG: Error decoding base64 image data:', bufferError);
-              throw new Error(`Failed to decode Gemini image data: ${bufferError}`);
-            }
-          }
-
-          // Also check for text responses (might indicate an error or different response type)
-          if (part.text && DEBUG) {
-            console.log('DEBUG: Text part in response:', part.text.substring(0, 200) + '...');
-          }
+      const savedPath = extractImageFromGeminiResponse(result);
+      if (savedPath) {
+        if (attempt > 1) {
+          console.log(`Gemini image generation succeeded on attempt ${attempt}/${GEMINI_IMAGE_MAX_ATTEMPTS}`);
         }
+        return savedPath;
+      }
+
+      const candidate = result.response.candidates?.[0];
+      const partsSummary = summarizeGeminiParts(candidate?.content?.parts || []);
+      console.warn(
+        `Gemini returned no image data (attempt ${attempt}/${GEMINI_IMAGE_MAX_ATTEMPTS}) ` +
+        `finishReason=${candidate?.finishReason ?? 'none'} parts=[${partsSummary}]`
+      );
+
+      if (attempt < GEMINI_IMAGE_MAX_ATTEMPTS) {
+        await sleep(400 * attempt);
       }
     }
 

--- a/src/tests/geminiRetry.test.ts
+++ b/src/tests/geminiRetry.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+
+const mockGenerateContent = jest.fn();
+
+jest.mock('@google/generative-ai', () => ({
+    GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
+        getGenerativeModel: jest.fn().mockReturnValue({
+            generateContent: mockGenerateContent
+        })
+    }))
+}));
+
+jest.mock('../config', () => ({
+    GEMINI_API_KEY: 'test-gemini-key',
+    DEBUG: false,
+    GEMINI_IMAGE_MAX_ATTEMPTS: 3
+}));
+
+import { generateImageWithGemini } from '../services/geminiService';
+
+describe('Gemini image generation retries', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('retries when the first response has no image data', async () => {
+        const pngBytes = Buffer.from([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        ]);
+
+        mockGenerateContent
+            .mockResolvedValueOnce({
+                response: {
+                    candidates: [{
+                        finishReason: 'STOP',
+                        content: { parts: [{ text: '' }] }
+                    }]
+                }
+            })
+            .mockResolvedValueOnce({
+                response: {
+                    candidates: [{
+                        finishReason: 'STOP',
+                        content: {
+                            parts: [{
+                                inlineData: {
+                                    data: pngBytes.toString('base64'),
+                                    mimeType: 'image/png'
+                                }
+                            }]
+                        }
+                    }]
+                }
+            });
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const result = await generateImageWithGemini({ prompt: 'test avatar' });
+
+        expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+        expect(fs.existsSync(result)).toBe(true);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/3'));
+
+        fs.unlinkSync(result);
+        warnSpy.mockRestore();
+    });
+
+    test('throws after exhausting retries', async () => {
+        mockGenerateContent.mockResolvedValue({
+            response: {
+                candidates: [{
+                    finishReason: 'STOP',
+                    content: { parts: [{ text: '' }] }
+                }]
+            }
+        });
+
+        await expect(generateImageWithGemini({ prompt: 'test avatar' })).rejects.toThrow(
+            'No image data found in Gemini SDK response'
+        );
+        expect(mockGenerateContent).toHaveBeenCalledTimes(3);
+    });
+});

--- a/src/tests/imageGeneration.integration.test.ts
+++ b/src/tests/imageGeneration.integration.test.ts
@@ -57,31 +57,32 @@ describe('Image Generation Integration Tests', () => {
                                !!process.env.GEMINI_API_KEY;
 
     (runIntegrationTests ? describe : describe.skip)('Real Image Generation', () => {
-        test('should generate image with DALL-E', async () => {
+        test('should generate image with OpenAI (dalle engine)', async () => {
             const options: ImageGenerationOptions = {
                 prompt: 'Abstract neon landscape forming from digital mist — silhouettes emerging slowly, illuminated by pulsating light waves. The mood is mysterious and anticipatory, like a world booting up to sound. Stylized digital artwork, club visual art.',
                 engine: 'dalle'
             };
 
-            const imageUrl = await generateImageWithOptions(options);
+            const imageResult = await generateImageWithOptions(options);
 
-            // Should return a URL for DALL-E
-            expect(typeof imageUrl).toBe('string');
-            expect(imageUrl.startsWith('http')).toBe(true);
+            expect(typeof imageResult).toBe('string');
 
-            // Download and save the image to dated output directory
-            const filename = `dalle-blue-circle-${Date.now()}.png`;
+            const filename = `openai-image-${Date.now()}.png`;
             const outputPath = path.join(outputDir, filename);
-            await downloadAndSaveImage(imageUrl, outputPath);
 
-            // Verify the downloaded file exists
+            if (imageResult.startsWith('http')) {
+                await downloadAndSaveImage(imageResult, outputPath);
+            } else {
+                fs.copyFileSync(imageResult, outputPath);
+            }
+
             expect(fs.existsSync(outputPath)).toBe(true);
             const stats = fs.statSync(outputPath);
-            expect(stats.size).toBeGreaterThan(1000); // At least 1KB
+            expect(stats.size).toBeGreaterThan(1000);
 
-            console.log('✅ DALL-E generated image URL:', imageUrl);
+            console.log('✅ OpenAI generated image:', imageResult.startsWith('http') ? imageResult : path.relative(process.cwd(), imageResult));
             console.log('📁 Preserved in output directory:', path.relative(process.cwd(), outputPath));
-        }, 30000); // 30 second timeout
+        }, 60000);
 
         test('should generate image with Gemini text-to-image', async () => {
             const options: ImageGenerationOptions = {

--- a/src/tests/openaiImage.test.ts
+++ b/src/tests/openaiImage.test.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import * as fs from 'fs';
+import * as path from 'path';
+import { generateImageWithOpenAI } from '../utils/imageUtils';
+
+jest.mock('axios');
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe('generateImageWithOpenAI', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('returns URL when OpenAI responds with url', async () => {
+        mockAxios.post.mockResolvedValue({
+            data: { data: [{ url: 'https://example.com/image.png' }] }
+        });
+
+        const result = await generateImageWithOpenAI('blue circle');
+        expect(result).toBe('https://example.com/image.png');
+        expect(mockAxios.post).toHaveBeenCalledWith(
+            'https://api.openai.com/v1/images/generations',
+            expect.objectContaining({ model: expect.any(String), prompt: 'blue circle' }),
+            expect.any(Object)
+        );
+    });
+
+    test('writes temp file when OpenAI responds with b64_json', async () => {
+        const pngBytes = Buffer.from([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        ]);
+        mockAxios.post.mockResolvedValue({
+            data: { data: [{ b64_json: pngBytes.toString('base64') }] }
+        });
+
+        const result = await generateImageWithOpenAI('blue circle');
+        expect(fs.existsSync(result)).toBe(true);
+        expect(result).toContain('openai-generated-');
+        fs.unlinkSync(result);
+    });
+
+    test('throws when response has neither url nor b64_json', async () => {
+        mockAxios.post.mockResolvedValue({ data: { data: [{}] } });
+        await expect(generateImageWithOpenAI('blue circle')).rejects.toThrow('missing url and b64_json');
+    });
+});

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,4 +1,4 @@
-import { DEBUG, OPENAI_API_KEY, WATERMARK_PATH, ImageEngine, getDEFAULT_ENGINE } from '../config';
+import { DEBUG, OPENAI_API_KEY, OPENAI_IMAGE_MODEL, WATERMARK_PATH, ImageEngine, getDEFAULT_ENGINE } from '../config';
 import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -31,6 +31,42 @@ export interface ImageGenerationOptions {
   geminiModel?: GeminiImageModelType;
   imageInput?: string; // For image-to-image generation
   useAnalysis?: boolean; // Whether to use double-LLM analysis for better prompts (default: true)
+}
+
+/** OpenAI Images API — returns a download URL or a local temp file path (gpt-image-* uses b64_json). */
+export async function generateImageWithOpenAI(prompt: string): Promise<string> {
+    if (!OPENAI_API_KEY) {
+        throw new Error('OPENAI_API_KEY is required for OpenAI image generation. Please set the OPENAI_API_KEY environment variable.');
+    }
+
+    const response = await axios.post('https://api.openai.com/v1/images/generations', {
+        model: OPENAI_IMAGE_MODEL,
+        prompt,
+        n: 1,
+        size: '1024x1024'
+    }, {
+        headers: {
+            'Authorization': `Bearer ${OPENAI_API_KEY}`,
+            'Content-Type': 'application/json'
+        }
+    });
+
+    const item = response.data?.data?.[0];
+    if (!item) {
+        throw new Error('OpenAI image API returned no data');
+    }
+
+    if (item.url) {
+        return item.url;
+    }
+
+    if (item.b64_json) {
+        const outputPath = path.join(tempDir, `openai-generated-${Date.now()}.png`);
+        fs.writeFileSync(outputPath, Buffer.from(item.b64_json, 'base64'));
+        return outputPath;
+    }
+
+    throw new Error('OpenAI image API response missing url and b64_json');
 }
 
 // Function to generate image via API (DALL-E or Gemini)
@@ -69,24 +105,7 @@ export async function generateImageWithOptions(options: ImageGenerationOptions):
         useAnalysis
       });
       } else {
-    // Default to DALL-E
-    if (!OPENAI_API_KEY) {
-        throw new Error('OPENAI_API_KEY is required for DALL-E image generation. Please set the OPENAI_API_KEY environment variable.');
-    }
-
-        const response = await axios.post('https://api.openai.com/v1/images/generations', {
-            model: 'dall-e-3',
-            prompt: sanitizedPrompt,
-            n: 1,
-            size: "1024x1024"
-        }, {
-            headers: {
-                'Authorization': `Bearer ${OPENAI_API_KEY}`,
-                'Content-Type': 'application/json'
-            }
-        });
-
-        return response.data.data[0].url;
+        return await generateImageWithOpenAI(sanitizedPrompt);
       }
     } catch (primaryError: any) {
       const primaryErrorMessage = primaryError.message || 'Unknown error occurred';
@@ -108,24 +127,7 @@ export async function generateImageWithOptions(options: ImageGenerationOptions):
             useAnalysis: false // Disable analysis for fallback to avoid further issues
           });
                 } else {
-          // Fallback to DALL-E
-          if (!OPENAI_API_KEY) {
-            throw new Error('OPENAI_API_KEY is required for DALL-E fallback. Please set the OPENAI_API_KEY environment variable.');
-          }
-
-          const response = await axios.post('https://api.openai.com/v1/images/generations', {
-            model: 'dall-e-3',
-            prompt: prompt,
-            n: 1,
-            size: "1024x1024"
-          }, {
-            headers: {
-              'Authorization': `Bearer ${OPENAI_API_KEY}`,
-              'Content-Type': 'application/json'
-            }
-          });
-
-          return response.data.data[0].url;
+          return await generateImageWithOpenAI(prompt);
                 }
       } catch (fallbackError: any) {
         const fallbackErrorMessage = fallbackError.message || 'Unknown fallback error';


### PR DESCRIPTION
Fixes #119

## Problem
- Gemini `gemini-2.5-flash-image` intermittently returns empty `parts: [{text:""}]` (~40% on some welcome prompts in prod)
- OpenAI fallback hardcoded `dall-e-3` but prod key only has `gpt-image-1`/`gpt-image-2` — fallback always 400

## Fix
- Retry Gemini up to 3× with backoff on empty image payload; warn-log each empty attempt
- `OPENAI_IMAGE_MODEL` env (default `gpt-image-1`); handle `b64_json` + `url` from Images API
- AGENTS.md: document deploy path (`main` → `docker-latest.yml` → Coolify)

## Test plan
- [x] `npm test` — 56 passed
- [x] New unit tests: `geminiRetry.test.ts`, `openaiImage.test.ts`
- [ ] After merge: confirm `docker-latest` green and Coolify pulls new `:latest`


Made with [Cursor](https://cursor.com)