### PR TITLE
fix(cost): invoke bq via execFileSync to avoid shell backtick expansion

### DIFF
--- a/src/services/costMonitoringService.ts
+++ b/src/services/costMonitoringService.ts
@@ -1,6 +1,6 @@
 import { Client, TextChannel } from 'discord.js';
 import { BOTSPAM_CHANNEL_ID, GEMINI_API_KEY, GOOGLE_CLOUD_PROJECT_ID } from '../config';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -100,10 +100,24 @@ export class CostMonitoringService {
         ORDER BY is_current_month DESC
       `;
 
-      const result = execSync(`bq --project_id=${GOOGLE_CLOUD_PROJECT_ID} query --use_legacy_sql=false "${query}" --format=csv`, {
-        encoding: 'utf8',
-        timeout: 30000
-      });
+      // Use execFileSync (argv array) — never a shell string. The SQL uses
+      // BigQuery backticks around the table name; a double-quoted shell
+      // command would expand those as command substitution and fail with
+      // `/bin/sh: ...gcp_billing_export_v1_*: not found`.
+      const result = execFileSync(
+        'bq',
+        [
+          `--project_id=${GOOGLE_CLOUD_PROJECT_ID}`,
+          'query',
+          '--use_legacy_sql=false',
+          '--format=csv',
+          query,
+        ],
+        {
+          encoding: 'utf8',
+          timeout: 30000,
+        }
+      );
 
       // Parse CSV result with improved error handling
       const lines = result.trim().split('\n');

--- a/src/tests/costMonitoring.test.ts
+++ b/src/tests/costMonitoring.test.ts
@@ -1,0 +1,44 @@
+import { Client } from 'discord.js';
+
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+  execSync: jest.fn(),
+}));
+
+jest.mock('../config', () => ({
+  BOTSPAM_CHANNEL_ID: 'channel-1',
+  GEMINI_API_KEY: 'test-gemini-key',
+  GOOGLE_CLOUD_PROJECT_ID: 'gen-lang-client-test',
+}));
+
+import { execFileSync, execSync } from 'child_process';
+import { CostMonitoringService } from '../services/costMonitoringService';
+
+const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe('CostMonitoringService BigQuery invocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calls bq via execFileSync argv (no shell) so backticks are not expanded', async () => {
+    mockExecFileSync.mockReturnValue('total_cost,is_current_month\n12.5,true\n40.0,false\n' as any);
+
+    const service = new CostMonitoringService({} as Client);
+    const costs = await service.getAllCosts();
+
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+
+    const [cmd, args] = mockExecFileSync.mock.calls[0];
+    expect(cmd).toBe('bq');
+    expect(args?.[0]).toBe('--project_id=gen-lang-client-test');
+    expect(args?.[1]).toBe('query');
+    expect(args?.[args.length - 1]).toContain('`gen-lang-client-test.billing_data.gcp_billing_export_v1_*`');
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].thisMonth).toBe(12.5);
+    expect(costs[0].lifetime).toBe(52.5);
+  });
+});


### PR DESCRIPTION
Fixes #127

**Problem:** After wiring BigQuery SA creds into Coolify, cost monitoring still failed with `/bin/sh: ...gcp_billing_export_v1_*: not found` because the SQL backticks were expanded by the shell.

**Fix:** Use `execFileSync('bq', [...args, query])` so the query is never interpreted by `/bin/sh`.

**Also done on Coolify (ops, not in this PR):**
- Created SA `hello-dalle-bq@gen-lang-client-0897480548`
- Mounted key + `CLOUDSDK_CONFIG` / `GOOGLE_APPLICATION_CREDENTIALS` on the persistent data volume

## Test plan
- [x] Unit test asserts argv-based `bq` invocation
- [x] Full jest suite
- [ ] After merge: Coolify pulls `:latest`, restart, confirm Cost Report in #botspam


Made with [Cursor](https://cursor.com)