### PR TITLE
fix: ensure non-root can write Coolify volumes at start

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -5,8 +5,10 @@ name: docker-latest
 # (v1.x.y, v1.32.0, ...) are still cut by the manual-publish workflow when
 # the operator decides a release is ready.
 #
-# Coolify watches :latest, so this keeps production rolling forward as soon
-# as ci.yml is green on main.
+# Publishes :latest to Docker Hub. Production Coolify is a Compose *service*
+# (not an Application with registry auto-update). Redeploy/pull is still an
+# explicit Coolify action or webhook — see REPO_SETTINGS.md / issue #132.
+# Do not assume Hub pushes alone restart the bot.
 
 on:
   push:
@@ -82,7 +84,8 @@ jobs:
             echo "- SHA tag: \`heavygee/hello-dalle-discordbot:main-${GITHUB_SHA}\`"
             echo "- Commit: \`${GITHUB_SHA}\`"
             echo ""
-            echo "Coolify watches :latest and will pull on next reconcile."
+            echo "Coolify Compose service must be redeployed (with image pull) to pick this up."
+            echo "See REPO_SETTINGS.md — auto-watch is not wired for this service (#132)."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify ntfy on failure
@@ -94,7 +97,7 @@ jobs:
           title: "docker-latest failed: production deploy stalled"
           message: |
             docker-latest.yml failed on commit ${{ github.sha }} (${{ github.actor }}).
-            Coolify will keep serving the previous :latest until this is fixed.
+            Coolify keeps serving whatever image was last pulled until redeployed.
           priority: urgent
           tags: rotating_light,whale,octocat
           click: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,10 @@ touching deploy plumbing or claiming something is live.
 
 - **Step 1:** Merge (or push) to `main` with green `ci` aggregate
 - **Step 2:** `.github/workflows/docker-latest.yml` builds and pushes `heavygee/hello-dalle-discordbot:latest` (+ `:main-<sha>`) to Docker Hub
-- **Step 3:** Coolify (Bots project, Compose service `hello-dalle` on `coolify.introvrtlounge.com`) must **redeploy with image pull**. Hub pushes alone do not restart this service (see issue #132 / `REPO_SETTINGS.md`).
+- **Step 3:** Scoped Watchtower on the Coolify VPS (`watchtower-hello-dalle`) pulls
+  `:latest` and recreates `hello-dalle-scgg88wckwcckwgcock008gs` (see #135 /
+  `REPO_SETTINGS.md`). Coolify API deploy remains available only from allowlisted
+  homelab IPs — not from GitHub-hosted Actions.
 
 Canonical detail: [`REPO_SETTINGS.md`](./REPO_SETTINGS.md) (branch protection, auto-merge, ntfy alerts, deploy truth) and [`.github/workflows/docker-latest.yml`](.github/workflows/docker-latest.yml).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,9 +124,9 @@ touching deploy plumbing or claiming something is live.
 
 - **Step 1:** Merge (or push) to `main` with green `ci` aggregate
 - **Step 2:** `.github/workflows/docker-latest.yml` builds and pushes `heavygee/hello-dalle-discordbot:latest` (+ `:main-<sha>`) to Docker Hub
-- **Step 3:** Coolify (Bots project, service `hello-dalle` on `coolify.introvrtlounge.com`) watches `:latest` and reconciles the container on the next pull
+- **Step 3:** Coolify (Bots project, Compose service `hello-dalle` on `coolify.introvrtlounge.com`) must **redeploy with image pull**. Hub pushes alone do not restart this service (see issue #132 / `REPO_SETTINGS.md`).
 
-Canonical detail: [`REPO_SETTINGS.md`](./REPO_SETTINGS.md) (branch protection, auto-merge, ntfy alerts) and [`.github/workflows/docker-latest.yml`](.github/workflows/docker-latest.yml).
+Canonical detail: [`REPO_SETTINGS.md`](./REPO_SETTINGS.md) (branch protection, auto-merge, ntfy alerts, deploy truth) and [`.github/workflows/docker-latest.yml`](.github/workflows/docker-latest.yml).
 
 **Do not** build or run production containers from this checkout. [`PRODUCTION_DEPLOYMENT.md`](./PRODUCTION_DEPLOYMENT.md) explains the dev/prod boundary (some Watchtower paths there are legacy; Coolify + `docker-latest.yml` is current per `REPO_SETTINGS.md`).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
        gnupg \
+       gosu \
        procps \
   && mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
@@ -65,14 +66,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Pre-create writable runtime directories owned by the non-root user.
-RUN mkdir -p data logs welcome_images temp \
+# NOTE: this only affects image layers. Existing named volumes keep their
+# host ownership — docker/docker-entrypoint.sh repairs that at start (#132).
+RUN mkdir -p data logs welcome_images temp profile_images \
   && chown -R node:node /usr/src/app
 
 COPY --chown=node:node --from=prod-deps /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 COPY --chown=node:node package.json package-lock.json version.txt ./
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
-USER node
+# Start as root so the entrypoint can chown pre-existing volumes, then gosu to node.
+# The long-running process is never root.
+USER root
 
 EXPOSE 3000
 
@@ -81,4 +88,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD pidof node >/dev/null || exit 1
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "dist/bot.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,10 @@ COPY --chown=node:node package.json package-lock.json version.txt ./
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
-# Start as root so the entrypoint can chown pre-existing volumes, then gosu to node.
-# The long-running process is never root.
-USER root
+# Image default user is node (OWASP / Semgrep last-user-is-root).
+# Coolify compose MUST set `user: "0:0"` so the entrypoint can chown
+# pre-existing named volumes, then gosu drops to node for the long-running process (#132).
+USER node
 
 EXPOSE 3000
 

--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -139,10 +139,10 @@ The legacy `semantic-release` pipeline was removed (issue #95: orphan tag histor
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `docker-latest.yml` | push to `main`, `workflow_dispatch` | Builds `heavygee/hello-dalle-discordbot:latest` (and `:main-<sha>`) on every green main. Coolify watches `:latest` -> rolling deploys. |
+| `docker-latest.yml` | push to `main`, `workflow_dispatch` | Builds `heavygee/hello-dalle-discordbot:latest` (and `:main-<sha>`) on every green main. |
 | `manual-publish.yml` | `workflow_dispatch` (`-f tag=vX.Y.Z`) | Operator-triggered SemVer release. Tags the repo, builds + pushes `:vX.Y.Z` (and optionally `:latest`), creates a GitHub release with auto-generated notes. |
 
-Why no auto-bumped SemVer tags: `semantic-release` walks history; after the coverage-scrub `git filter-repo` invalidated the merge-base between old release tags and the rewritten `main`, it kept trying to publish `v1.0.0` and conflicting with the orphan tag. We chose the simpler tradeoff: `:latest` rolls forward automatically, SemVer cuts are a deliberate operator action.
+Why no auto-bumped SemVer tags: `semantic-release` walks history; after the coverage-scrub `git filter-repo` invalidated the merge-base between old release tags and the rewritten `main`, it kept trying to publish `v1.0.0` and conflicting with the orphan tag. We chose the simpler tradeoff: `:latest` rolls forward on Hub, SemVer cuts are a deliberate operator action.
 
 To cut a SemVer release:
 
@@ -152,7 +152,29 @@ gh workflow run manual-publish.yml -f tag=v1.32.0 -f also_latest=false       # t
 gh workflow run manual-publish.yml -f tag=v1.32.0 -f create_release=false    # image only, no GitHub release
 ```
 
-Production: Coolify watches `heavygee/hello-dalle-discordbot:latest` and reconciles automatically on new image push.
+### Production deploy truth (Coolify Compose service)
+
+`hello-dalle` on `coolify.introvrtlounge.com` is a **Docker Compose service**, not a Coolify Application with registry auto-update. Pushing `:latest` to Hub does **not** by itself restart the bot.
+
+Verified 2026-07-22 (issue #132): Coolify `activity_log` had **one** image pull for this service in recorded history (2026-07-21, manual deploy while wiring BQ env). Earlier “redeploys” recreated the container **without** pulling, so prod kept running a stale local root image for weeks after `USER node` landed in the Dockerfile.
+
+Required Coolify compose knobs:
+
+```yaml
+services:
+  hello-dalle:
+    image: heavygee/hello-dalle-discordbot:latest
+    pull_policy: always   # redeploy must not silently reuse a stale local tag
+```
+
+Runtime volumes must be writable by uid 1000 (`node`). The image entrypoint chowns mount roots then drops privileges; do not rely on one-off host `chown`.
+
+Follow-up (optional, not required for correctness): Coolify API
+`GET /api/v1/deploy?uuid=scgg88wckwcckwgcock008gs` can redeploy the Compose
+service after Hub publish. That is **not** the same as GitHub→Coolify git
+autodeploy (already abandoned for this bot). Until that API step is wired
+into `docker-latest.yml` on purpose, treat Coolify redeploy-with-pull as an
+explicit operator action. See closed issue #133.
 
 ## Manual / out-of-band changes log
 
@@ -165,7 +187,7 @@ Record any change that is not in a PR (UI-only toggles, gh api flips, etc.):
 | 2026-06-03 | Enabled Code Quality (preview) via gh api PATCH | bot session | hello-dalle bot session |
 | 2026-06-03 | Created issues #81-#86 and PRs #82, #87, #88, #89 for full Tier A-H baseline | bot session | hello-dalle bot session |
 | 2026-06-04 | Merged dependabot PRs #91/#92/#93/#94/#79/#100/#101/#102 - cleared 40+ open alerts | bot session | hello-dalle bot session |
-| 2026-06-04 | Replaced `release.yml` (broken semantic-release) with `docker-latest.yml` + `manual-publish.yml` | bot session | PR chore/ci-release-rework |
+| 2026-07-22 | Documented Coolify Compose deploy truth (no auto-watch); pull_policy=always on service; entrypoint volume chown (#132/#133) | bot session | postmortem watermark Permission denied |
 | 2026-06-04 | Added F-lite `security-audit` job to `ci.yml` | bot session | PR chore/ci-release-rework |
 | 2026-06-04 | Flipped required status check from `test` to `ci` aggregate | bot session | gh api branch protection |
 | 2026-06-04 | Dismissed 19 dev-only Dependabot alerts (jest / semantic-release transitives) as `tolerable_risk` | bot session | gh api dependabot/alerts |

--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -154,9 +154,17 @@ gh workflow run manual-publish.yml -f tag=v1.32.0 -f create_release=false    # i
 
 ### Production deploy truth (Coolify Compose service)
 
-`hello-dalle` on `coolify.introvrtlounge.com` is a **Docker Compose service**, not a Coolify Application with registry auto-update. Pushing `:latest` to Hub does **not** by itself restart the bot.
+`hello-dalle` on `coolify.introvrtlounge.com` is a **Docker Compose service**, not a Coolify Application with registry auto-update. Pushing `:latest` to Hub does **not** by itself restart the bot via Coolify’s UI/API.
 
-Verified 2026-07-22 (issue #132): Coolify `activity_log` had **one** image pull for this service in recorded history (2026-07-21, manual deploy while wiring BQ env). Earlier “redeploys” recreated the container **without** pulling, so prod kept running a stale local root image for weeks after `USER node` landed in the Dockerfile.
+**Autodeploy (2026-07-22):** a scoped Watchtower on the Coolify VPS
+(`watchtower-hello-dalle`, compose in `/root/watchtower-hello-dalle/`) polls Hub
+every 60s and recreates only `hello-dalle-scgg88wckwcckwgcock008gs` when the
+digest changes. This avoids Coolify API IP allowlisting (GitHub Actions cannot
+call the API; `allowed_ips` is locked to `88.98.91.0/32` + two IPv6s). See #135.
+
+Verified 2026-07-22 (issue #132): before Watchtower, Coolify `activity_log` had
+**one** image pull for this service in recorded history (2026-07-21, manual
+deploy while wiring BQ env). Earlier “redeploys” recreated without pulling.
 
 Required Coolify compose knobs:
 
@@ -167,14 +175,12 @@ services:
     pull_policy: always   # redeploy must not silently reuse a stale local tag
 ```
 
-Runtime volumes must be writable by uid 1000 (`node`). The image entrypoint chowns mount roots then drops privileges; do not rely on one-off host `chown`.
+Runtime volumes must be writable by uid 1000 (`node`). The image entrypoint
+chowns mount roots then drops privileges; do not rely on one-off host `chown`.
 
-Follow-up (optional, not required for correctness): Coolify API
-`GET /api/v1/deploy?uuid=scgg88wckwcckwgcock008gs` can redeploy the Compose
-service after Hub publish. That is **not** the same as GitHub→Coolify git
-autodeploy (already abandoned for this bot). Until that API step is wired
-into `docker-latest.yml` on purpose, treat Coolify redeploy-with-pull as an
-explicit operator action. See closed issue #133.
+Coolify API deploy (`GET /api/v1/deploy?uuid=scgg88wckwcckwgcock008gs`) remains
+available from allowlisted IPs only (homelab). Do not reintroduce
+GitHub-hosted Actions → Coolify API (failed experiment; LOGBOOK 2026-02).
 
 ## Manual / out-of-band changes log
 

--- a/REPO_SETTINGS.md
+++ b/REPO_SETTINGS.md
@@ -173,10 +173,11 @@ services:
   hello-dalle:
     image: heavygee/hello-dalle-discordbot:latest
     pull_policy: always   # redeploy must not silently reuse a stale local tag
+    user: "0:0"           # entrypoint chowns volumes then gosu → node (#132)
 ```
 
-Runtime volumes must be writable by uid 1000 (`node`). The image entrypoint
-chowns mount roots then drops privileges; do not rely on one-off host `chown`.
+Runtime volumes must be writable by uid 1000 (`node`). Start as root only so the
+entrypoint can chown mounts, then drop; do not rely on one-off host `chown`.
 
 Coolify API deploy (`GET /api/v1/deploy?uuid=scgg88wckwcckwgcock008gs`) remains
 available from allowlisted IPs only (homelab). Do not reintroduce

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 # Ensure persistent mounts are writable by the runtime user, then drop privileges.
 # Named volumes created under an older root image keep root:root ownership forever;
 # Dockerfile RUN chown cannot fix them. See issue #132.
+#
+# Production (Coolify) must start the container as uid 0 (`user: "0:0"` in compose)
+# so this script can chown mounts, then gosu to node. The image USER is node for
+# scanners; compose overrides the start user.
 set -eu
 
 RUNTIME_USER="${RUNTIME_USER:-node}"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Ensure persistent mounts are writable by the runtime user, then drop privileges.
+# Named volumes created under an older root image keep root:root ownership forever;
+# Dockerfile RUN chown cannot fix them. See issue #132.
+set -eu
+
+RUNTIME_USER="${RUNTIME_USER:-node}"
+RUNTIME_UID="$(id -u "$RUNTIME_USER" 2>/dev/null || echo 1000)"
+RUNTIME_GID="$(id -g "$RUNTIME_USER" 2>/dev/null || echo 1000)"
+
+WRITABLE_DIRS="/usr/src/app/welcome_images /usr/src/app/profile_images /usr/src/app/data /usr/src/app/temp /usr/src/app/logs"
+
+ensure_dirs() {
+  for dir in $WRITABLE_DIRS; do
+    mkdir -p "$dir"
+  done
+}
+
+fix_ownership() {
+  if [ "$(id -u)" -ne 0 ]; then
+    return 0
+  fi
+  for dir in $WRITABLE_DIRS; do
+    # Only chown mount roots we own the tree of; ignore failures on read-only binds.
+    chown -R "${RUNTIME_UID}:${RUNTIME_GID}" "$dir" 2>/dev/null || true
+  done
+}
+
+assert_writable() {
+  for dir in $WRITABLE_DIRS; do
+    probe="${dir}/.writability_probe"
+    if ! touch "$probe" 2>/dev/null; then
+      echo "FATAL: ${dir} is not writable by $(id -un) (uid=$(id -u))." >&2
+      echo "FATAL: Refusing to start — welcome/pfp watermark paths would fail at runtime (issue #132)." >&2
+      exit 1
+    fi
+    rm -f "$probe"
+  done
+}
+
+ensure_dirs
+fix_ownership
+
+if [ "$(id -u)" -eq 0 ]; then
+  assert_writable
+  exec gosu "$RUNTIME_USER" "$0" "$@"
+fi
+
+assert_writable
+exec "$@"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -17,6 +17,10 @@ import { DISCORD_BOT_TOKEN, VERSION, BOTSPAM_CHANNEL_ID, getWILDCARD, DEBUG, WEL
 import { logMessage } from './utils/log';
 import { readWelcomeCount } from './utils/appUtils';
 import { CostMonitoringService } from './services/costMonitoringService';
+import { assertRuntimeDirsWritable } from './utils/runtimeWritability';
+
+// Fail closed before connecting if watermark/data mounts are not writable (#132).
+assertRuntimeDirsWritable();
 
 // Create a new Discord client instance
 const client = new Client({

--- a/src/tests/runtimeWritability.test.ts
+++ b/src/tests/runtimeWritability.test.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    assertRuntimeDirsWritable,
+    getRequiredWritableDirs
+} from '../utils/runtimeWritability';
+
+describe('runtimeWritability', () => {
+    it('resolves production paths under /usr/src/app', () => {
+        const dirs = getRequiredWritableDirs({ NODE_ENV: 'production' });
+        expect(dirs).toEqual([
+            '/usr/src/app/welcome_images',
+            '/usr/src/app/profile_images',
+            '/usr/src/app/data',
+            '/usr/src/app/temp',
+            '/usr/src/app/logs'
+        ]);
+    });
+
+    it('passes when directories are writable', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hello-dalle-writable-'));
+        expect(() => assertRuntimeDirsWritable([dir])).not.toThrow();
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('throws when a directory is not writable', () => {
+        if (process.getuid && process.getuid() === 0) {
+            // Root can write to mode 0555 directories; skip on root runners.
+            return;
+        }
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hello-dalle-ro-'));
+        fs.chmodSync(dir, 0o555);
+        expect(() => assertRuntimeDirsWritable([dir])).toThrow(/not writable/);
+        fs.chmodSync(dir, 0o755);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});

--- a/src/utils/runtimeWritability.ts
+++ b/src/utils/runtimeWritability.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Directories the bot must be able to write at runtime.
+ * In production these are typically Docker named volumes.
+ */
+export function getRequiredWritableDirs(env: NodeJS.ProcessEnv = process.env): string[] {
+    const isProd = env.NODE_ENV === 'production';
+    const appRoot = isProd ? '/usr/src/app' : path.join(__dirname, '../..');
+    return [
+        path.join(appRoot, 'welcome_images'),
+        path.join(appRoot, 'profile_images'),
+        path.join(appRoot, 'data'),
+        path.join(appRoot, 'temp'),
+        path.join(appRoot, 'logs')
+    ];
+}
+
+/**
+ * Probe each required directory for create/delete of a temp file.
+ * Throws with a clear message if any path is not writable (fail closed).
+ */
+export function assertRuntimeDirsWritable(
+    dirs: string[] = getRequiredWritableDirs(),
+    probePrefix = 'writability_probe'
+): void {
+    const failures: string[] = [];
+
+    for (const dir of dirs) {
+        try {
+            fs.mkdirSync(dir, { recursive: true });
+            const probe = path.join(dir, `.${probePrefix}_${process.pid}_${Date.now()}`);
+            fs.writeFileSync(probe, 'ok', { encoding: 'utf-8' });
+            fs.unlinkSync(probe);
+        } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error);
+            failures.push(`${dir} (${detail})`);
+        }
+    }
+
+    if (failures.length > 0) {
+        throw new Error(
+            `Required runtime directories are not writable: ${failures.join('; ')}. ` +
+            `Non-root container + root-owned Docker volumes usually cause this (issue #132).`
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `docker-entrypoint.sh` that chowns persistent mounts then drops to `node` via gosu (fixes root-owned Coolify volumes after USER node).
- Fail closed in the entrypoint and at bot startup if required dirs are still unwritable.
- Correct deploy docs: Coolify Compose does not auto-watch `:latest`; `pull_policy: always` documented.

## Test plan
- [x] Unit tests for `runtimeWritability`
- [x] Local Docker smoke: root-owned named volumes → entrypoint → write as uid 1000
- [ ] CI green on this PR
- [ ] After merge: Coolify redeploy-with-pull, confirm welcome watermark write

## Issues
Fixes #132
