### PR TITLE
fix: persist rejoin memory + one-shot 500 milestone

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -15,7 +15,13 @@ import { handleEngineSlashCommand } from './commands/engine';
 import { registerSlashCommands } from './commands/slashCommands';
 import { DISCORD_BOT_TOKEN, VERSION, BOTSPAM_CHANNEL_ID, getWILDCARD, DEBUG, WELCOME_CHANNEL_ID, PROFILE_CHANNEL_ID } from './config';
 import { logMessage } from './utils/log';
-import { readWelcomeCount } from './utils/appUtils';
+import {
+    readWelcomeCount,
+    getWelcomedUserCount,
+    seedWelcomedUsers,
+    hasCelebratedMilestone500,
+    markMilestone500Celebrated,
+} from './utils/appUtils';
 import { CostMonitoringService } from './services/costMonitoringService';
 import { assertRuntimeDirsWritable } from './utils/runtimeWritability';
 
@@ -67,8 +73,33 @@ client.once('ready', async () => {
             console.log(`Using cached count: ${humanMemberCount} human members`);
         }
 
+        // If we have welcome history but no welcomedUsers.json (lost volume / never written),
+        // seed current human IDs so rejoins don't get a full welcome again (#136).
+        if (welcomeCount > 0 && getWelcomedUserCount() === 0) {
+            const humanIds = guild.members.cache
+                .filter(m => !m.user.bot)
+                .map(m => m.user.id);
+            const seeded = seedWelcomedUsers(humanIds);
+            console.log(
+                `Seeded welcomedUsers.json with ${seeded} current human member IDs ` +
+                `(welcomeCount=${welcomeCount} but persist file was empty).`
+            );
+            await logMessage(
+                client,
+                guild,
+                `Recovered rejoin memory: seeded ${seeded} member IDs into welcomedUsers.json.`
+            );
+        }
+
+        // If we are already at/past 500 humans and never recorded the one-shot flag,
+        // mark it celebrated so a rejoin cannot re-fire the golden VIP welcome (#136).
+        if (humanMemberCount >= 500 && !hasCelebratedMilestone500()) {
+            markMilestone500Celebrated();
+            console.log('Marked milestone500 as already celebrated (server already at/past 500 humans).');
+        }
+
         // Construct the startup message
-        const startupMessage = `Bot is online! Version: ${VERSION}. Wildcard chance: ${getWILDCARD()}%. Total welcomed users so far: ${welcomeCount}. Active human members: ${humanMemberCount}`;
+        const startupMessage = `Bot is online! Version: ${VERSION}. Wildcard chance: ${getWILDCARD()}%. Total welcomed users so far: ${welcomeCount}. Active human members: ${humanMemberCount}. Remembered welcomes: ${getWelcomedUserCount()}`;
 
         // Log the startup message
         await logMessage(client, guild, startupMessage);

--- a/src/services/welcomeService.ts
+++ b/src/services/welcomeService.ts
@@ -7,7 +7,13 @@ import { analyzeImageContent } from './geminiService';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logMessage } from '../utils/log';
-import { readWelcomeCount, writeWelcomeCount, addWelcomedUser } from '../utils/appUtils';
+import {
+    readWelcomeCount,
+    writeWelcomeCount,
+    addWelcomedUser,
+    hasCelebratedMilestone500,
+    markMilestone500Celebrated,
+} from '../utils/appUtils';
 
 export let welcomeCount = readWelcomeCount();
 
@@ -63,7 +69,9 @@ export async function welcomeUser(client: Client, member: GuildMember, debugMode
         humanMemberCount = guild.members.cache.filter(member => !member.user.bot).size;
         if (DEBUG) console.log(`DEBUG: Using cached count: ${humanMemberCount} human members`);
     }
-    const isMilestoneWelcome = humanMemberCount === 500;
+    // One-shot: only the first time we ever hit exactly 500 humans. Rejoins that
+    // push the live count back to 500 must not re-fire the golden VIP welcome.
+    const isMilestoneWelcome = humanMemberCount === 500 && !hasCelebratedMilestone500();
 
     try {
         // Log the avatar URL
@@ -109,6 +117,12 @@ export async function welcomeUser(client: Client, member: GuildMember, debugMode
 
                 // Notify admins about profile picture generation
                 await notifyAdmins(client, guild, `Profile picture generated for user "${displayName}".`, []);
+
+                // Still record the user so a later rejoin skips the full welcome path (#136).
+                addWelcomedUser(userId);
+                welcomeCount++;
+                writeWelcomeCount(welcomeCount);
+                await logMessage(client, guild, `Welcome count updated (pfp-only path): ${welcomeCount}`);
 
                 // Exit after generating profile picture, no welcome image is needed in this case
                 return;
@@ -222,6 +236,9 @@ Make this the most spectacular welcome image ever created - fit for royalty! ✨
         welcomeCount++;
         writeWelcomeCount(welcomeCount);
         addWelcomedUser(userId);
+        if (isMilestoneWelcome) {
+            markMilestone500Celebrated();
+        }
         await logMessage(client, guild, `Welcome count updated: ${welcomeCount}`);
 
         // Clean up temp files

--- a/src/tests/welcomedUsers.test.ts
+++ b/src/tests/welcomedUsers.test.ts
@@ -4,29 +4,43 @@ import {
     hasWelcomedUser,
     addWelcomedUser,
     readWelcomedUserIds,
+    seedWelcomedUsers,
+    getWelcomedUserCount,
+    hasCelebratedMilestone500,
+    markMilestone500Celebrated,
     _resetWelcomedUsersCacheForTests,
 } from '../utils/appUtils';
 
 const welcomedUsersFilePath = path.join(__dirname, '../../data/welcomedUsers.json');
 const tmpFilePath = `${welcomedUsersFilePath}.tmp`;
+const milestone500FilePath = path.join(__dirname, '../../data/milestone500.json');
 
 describe('welcomedUsers persistence (appUtils)', () => {
     let backup: string | null = null;
+    let milestoneBackup: string | null = null;
 
     beforeEach(() => {
         backup = fs.existsSync(welcomedUsersFilePath)
             ? fs.readFileSync(welcomedUsersFilePath, 'utf-8')
             : null;
+        milestoneBackup = fs.existsSync(milestone500FilePath)
+            ? fs.readFileSync(milestone500FilePath, 'utf-8')
+            : null;
         if (fs.existsSync(welcomedUsersFilePath)) fs.unlinkSync(welcomedUsersFilePath);
         if (fs.existsSync(tmpFilePath)) fs.unlinkSync(tmpFilePath);
+        if (fs.existsSync(milestone500FilePath)) fs.unlinkSync(milestone500FilePath);
         _resetWelcomedUsersCacheForTests();
     });
 
     afterEach(() => {
         if (fs.existsSync(welcomedUsersFilePath)) fs.unlinkSync(welcomedUsersFilePath);
         if (fs.existsSync(tmpFilePath)) fs.unlinkSync(tmpFilePath);
+        if (fs.existsSync(milestone500FilePath)) fs.unlinkSync(milestone500FilePath);
         if (backup !== null) {
             fs.writeFileSync(welcomedUsersFilePath, backup, 'utf-8');
+        }
+        if (milestoneBackup !== null) {
+            fs.writeFileSync(milestone500FilePath, milestoneBackup, 'utf-8');
         }
         _resetWelcomedUsersCacheForTests();
     });
@@ -87,5 +101,35 @@ describe('welcomedUsers persistence (appUtils)', () => {
     it('does not leave a .tmp file behind after a successful write', () => {
         addWelcomedUser('111');
         expect(fs.existsSync(tmpFilePath)).toBe(false);
+    });
+
+    it('seedWelcomedUsers bulk-adds and skips duplicates', () => {
+        addWelcomedUser('111');
+        const added = seedWelcomedUsers(['111', '222', '333']);
+        expect(added).toBe(2);
+        expect(getWelcomedUserCount()).toBe(3);
+        expect(hasWelcomedUser('222')).toBe(true);
+        expect(hasWelcomedUser('333')).toBe(true);
+    });
+
+    it('seedWelcomedUsers persists across cache reset', () => {
+        seedWelcomedUsers(['aaa', 'bbb']);
+        _resetWelcomedUsersCacheForTests();
+        expect(readWelcomedUserIds().sort()).toEqual(['aaa', 'bbb']);
+    });
+
+    it('milestone500 starts uncelebrated and becomes one-shot after mark', () => {
+        expect(hasCelebratedMilestone500()).toBe(false);
+        markMilestone500Celebrated();
+        expect(hasCelebratedMilestone500()).toBe(true);
+        const raw = JSON.parse(fs.readFileSync(milestone500FilePath, 'utf-8'));
+        expect(raw.celebrated).toBe(true);
+        expect(typeof raw.celebratedAt).toBe('string');
+    });
+
+    it('milestone500 survives as celebrated after file re-read', () => {
+        markMilestone500Celebrated();
+        expect(hasCelebratedMilestone500()).toBe(true);
+        expect(hasCelebratedMilestone500()).toBe(true);
     });
 });

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -6,6 +6,7 @@ const dataDir = path.join(__dirname, '../../data');
 const welcomeCountFilePath = path.join(dataDir, 'welcomeCount.json');
 const imageDescriptionCacheFilePath = path.join(dataDir, 'imageDescriptionCache.json');
 const welcomedUsersFilePath = path.join(dataDir, 'welcomedUsers.json');
+const milestone500FilePath = path.join(dataDir, 'milestone500.json');
 
 // Ensure the data directory exists
 if (!fs.existsSync(dataDir)) {
@@ -43,9 +44,20 @@ function ensureCacheLoaded(): Set<string> {
 function persistWelcomedUserIds(ids: Set<string>): void {
     // Atomic write: stage to tmp then rename so a crash mid-write cannot corrupt the file.
     const tmpPath = `${welcomedUsersFilePath}.tmp`;
-    const payload = JSON.stringify({ ids: Array.from(ids) }, null, 2);
-    fs.writeFileSync(tmpPath, payload, { encoding: 'utf-8' });
-    fs.renameSync(tmpPath, welcomedUsersFilePath);
+    try {
+        if (!fs.existsSync(dataDir)) {
+            fs.mkdirSync(dataDir, { recursive: true });
+        }
+        const payload = JSON.stringify({ ids: Array.from(ids) }, null, 2);
+        fs.writeFileSync(tmpPath, payload, { encoding: 'utf-8' });
+        fs.renameSync(tmpPath, welcomedUsersFilePath);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+            `FATAL: failed to persist welcomedUsers.json (${ids.size} ids) to ${welcomedUsersFilePath}: ${message}`
+        );
+        throw error;
+    }
 }
 
 export function hasWelcomedUser(userId: string): boolean {
@@ -60,8 +72,51 @@ export function addWelcomedUser(userId: string): void {
     persistWelcomedUserIds(ids);
 }
 
+/** Bulk-add IDs (e.g. seed current roster when the persist file was lost). Returns how many were newly added. */
+export function seedWelcomedUsers(userIds: string[]): number {
+    const ids = ensureCacheLoaded();
+    let added = 0;
+    for (const raw of userIds) {
+        const id = String(raw);
+        if (ids.has(id)) continue;
+        ids.add(id);
+        added++;
+    }
+    if (added > 0) {
+        persistWelcomedUserIds(ids);
+    }
+    return added;
+}
+
 export function readWelcomedUserIds(): string[] {
     return Array.from(ensureCacheLoaded());
+}
+
+export function getWelcomedUserCount(): number {
+    return ensureCacheLoaded().size;
+}
+
+/** True when the golden 500-member VIP welcome has already been fired once. */
+export function hasCelebratedMilestone500(): boolean {
+    if (!fs.existsSync(milestone500FilePath)) {
+        return false;
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(milestone500FilePath, { encoding: 'utf-8' }));
+        return parsed?.celebrated === true;
+    } catch (error) {
+        console.warn('Error reading milestone500.json, treating as not celebrated:', error);
+        return false;
+    }
+}
+
+export function markMilestone500Celebrated(): void {
+    const payload = JSON.stringify(
+        { celebrated: true, celebratedAt: new Date().toISOString() },
+        null,
+        2
+    );
+    fs.writeFileSync(milestone500FilePath, payload, { encoding: 'utf-8' });
 }
 
 // Test-only: drop the in-memory cache so the next access reloads from disk.


### PR DESCRIPTION
## Summary
- Persist `welcomedUsers.json` more loudly, seed current human IDs at startup when `welcomeCount > 0` but the file is empty (prod gap that let rejoins look brand-new).
- Record welcomed users on the pfp-only early-return path so those IDs are not lost.
- One-shot the golden 500 VIP welcome via `milestone500.json`; at startup mark it celebrated if the server is already at/past 500 humans.

## Test plan
- [x] `npm test` (64 passed)
- [ ] After merge/deploy: Coolify data volume has `welcomedUsers.json` and `milestone500.json`
- [ ] Rejoin of an existing member gets “Welcome back”, not a full image / VIP welcome

Fixes #136

Made with [Cursor](https://cursor.com)